### PR TITLE
docs: update README to use relative repo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ moving from managing coding agents to managing work that needs to get done.
 Tell your favorite coding agent to build Symphony in a programming language of your choice:
 
 > Implement Symphony according to the following spec:
-> https://github.com/openai/symphony/blob/main/SPEC.md
+> ./SPEC.md
 
 ### Option 2. Use our experimental reference implementation
 
@@ -32,7 +32,7 @@ and run the Elixir-based Symphony implementation. You can also ask your favorite
 help with the setup:
 
 > Set up Symphony for my repository based on
-> https://github.com/openai/symphony/blob/main/elixir/README.md
+> ./elixir/README.md
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace absolute GitHub URLs pointing to openai/symphony with relative paths
- README.md now references `./SPEC.md` and `./elixir/README.md` instead of absolute openai/symphony URLs

## Test Plan

- [ ] `make -C elixir all`
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)