### PR TITLE
docs: replace openai/symphony with logitropic/symphony in URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ moving from managing coding agents to managing work that needs to get done.
 Tell your favorite coding agent to build Symphony in a programming language of your choice:
 
 > Implement Symphony according to the following spec:
-> https://github.com/openai/symphony/blob/main/SPEC.md
+> https://github.com/logitropic/symphony/blob/main/SPEC.md
 
 ### Option 2. Use our experimental reference implementation
 
@@ -32,7 +32,7 @@ and run the Elixir-based Symphony implementation. You can also ask your favorite
 help with the setup:
 
 > Set up Symphony for my repository based on
-> https://github.com/openai/symphony/blob/main/elixir/README.md
+> https://github.com/logitropic/symphony/blob/main/elixir/README.md
 
 ---
 

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -56,7 +56,7 @@ mise exec -- elixir --version
 ## Run
 
 ```bash
-git clone https://github.com/openai/symphony
+git clone https://github.com/logitropic/symphony
 cd symphony/elixir
 mise trust
 mise install

--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -19,7 +19,7 @@ workspace:
   root: ~/code/symphony-workspaces
 hooks:
   after_create: |
-    git clone --depth 1 https://github.com/openai/symphony .
+    git clone --depth 1 https://github.com/logitropic/symphony .
     if command -v mise >/dev/null 2>&1; then
       cd elixir && mise trust && mise exec -- mix deps.get
     fi

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -105,7 +105,7 @@ defmodule SymphonyElixir.CoreTest do
 
     hooks = Map.get(config, "hooks", %{})
     assert is_map(hooks)
-    assert Map.get(hooks, "after_create") =~ "git clone --depth 1 https://github.com/openai/symphony ."
+    assert Map.get(hooks, "after_create") =~ "git clone --depth 1 https://github.com/logitropic/symphony ."
     assert Map.get(hooks, "after_create") =~ "cd elixir && mise trust"
     assert Map.get(hooks, "after_create") =~ "mise exec -- mix deps.get"
     assert Map.get(hooks, "before_remove") =~ "cd elixir && mise exec -- mix workspace.before_remove"


### PR DESCRIPTION
## Summary
- Replaced all occurrences of `github.com/openai/symphony` with `github.com/logitropic/symphony` across README files and test

## Test plan
- [x] `grep` confirms zero occurrences of `openai/symphony` remain in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)