### PR TITLE
Refactor Symphony to Claude-only runtime

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: commit
+description:
+  Create a well-formed git commit from current changes using session history for
+  rationale and summary; use when asked to commit, prepare a commit message, or
+  finalize staged work.
+---
+
+# Commit
+
+## Goals
+
+- Produce a commit that reflects the actual code changes and the session
+  context.
+- Follow common git conventions (type prefix, short subject, wrapped body).
+- Include both summary and rationale in the body.
+
+## Inputs
+
+- Claude session history for intent and rationale.
+- `git status`, `git diff`, and `git diff --staged` for actual changes.
+- Repo-specific commit conventions if documented.
+
+## Steps
+
+1. Read session history to identify scope, intent, and rationale.
+2. Inspect the working tree and staged changes (`git status`, `git diff`,
+   `git diff --staged`).
+3. Stage intended changes, including new files (`git add -A`) after confirming
+   scope.
+4. Sanity-check newly added files; if anything looks random or likely ignored
+   (build artifacts, logs, temp files), flag it to the user before committing.
+5. If staging is incomplete or includes unrelated files, fix the index or ask
+   for confirmation.
+6. Choose a conventional type and optional scope that match the change (e.g.,
+   `feat(scope): ...`, `fix(scope): ...`, `refactor(scope): ...`).
+7. Write a subject line in imperative mood, <= 72 characters, no trailing
+   period.
+8. Write a body that includes:
+   - Summary of key changes (what changed).
+   - Rationale and trade-offs (why it changed).
+   - Tests or validation run (or explicit note if not run).
+9. Append a `Co-authored-by` trailer for Claude using `Claude <claude@openai.com>`
+   unless the user explicitly requests a different identity.
+10. Wrap body lines at 72 characters.
+11. Create the commit message with a here-doc or temp file and use
+    `git commit -F <file>` so newlines are literal (avoid `-m` with `\n`).
+12. Commit only when the message matches the staged changes: if the staged diff
+    includes unrelated files or the message describes work that isn't staged,
+    fix the index or revise the message before committing.
+
+## Output
+
+- A single commit created with `git commit` whose message reflects the session.
+
+## Template
+
+Type and scope are examples only; adjust to fit the repo and changes.
+
+```
+<type>(<scope>): <short summary>
+
+Summary:
+- <what changed>
+- <what changed>
+
+Rationale:
+- <why>
+- <why>
+
+Tests:
+- <command or "not run (reason)">
+
+Co-authored-by: Claude <claude@openai.com>
+```

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: debug
+description:
+  Investigate stuck runs and execution failures by tracing Symphony and Claude
+  logs with issue/session identifiers; use when runs stall, retry repeatedly, or
+  fail unexpectedly.
+---
+
+# Debug
+
+## Goals
+
+- Find why a run is stuck, retrying, or failing.
+- Correlate Linear issue identity to a Claude session quickly.
+- Read the right logs in the right order to isolate root cause.
+
+## Log Sources
+
+- Primary runtime log: `log/symphony.log`
+  - Default comes from `SymphonyElixir.LogFile` (`log/symphony.log`).
+  - Includes orchestrator, agent runner, and Claude app-server lifecycle logs.
+- Rotated runtime logs: `log/symphony.log*`
+  - Check these when the relevant run is older.
+
+## Correlation Keys
+
+- `issue_identifier`: human ticket key (example: `MT-625`)
+- `issue_id`: Linear UUID (stable internal ID)
+- `session_id`: Claude thread-turn pair (`<thread_id>-<turn_id>`)
+
+`elixir/docs/logging.md` requires these fields for issue/session lifecycle logs. Use
+them as your join keys during debugging.
+
+## Quick Triage (Stuck Run)
+
+1. Confirm scheduler/worker symptoms for the ticket.
+2. Find recent lines for the ticket (`issue_identifier` first).
+3. Extract `session_id` from matching lines.
+4. Trace that `session_id` across start, stream, completion/failure, and stall
+   handling logs.
+5. Decide class of failure: timeout/stall, app-server startup failure, turn
+   failure, or orchestrator retry loop.
+
+## Commands
+
+```bash
+# 1) Narrow by ticket key (fastest entry point)
+rg -n "issue_identifier=MT-625" log/symphony.log*
+
+# 2) If needed, narrow by Linear UUID
+rg -n "issue_id=<linear-uuid>" log/symphony.log*
+
+# 3) Pull session IDs seen for that ticket
+rg -o "session_id=[^ ;]+" log/symphony.log* | sort -u
+
+# 4) Trace one session end-to-end
+rg -n "session_id=<thread>-<turn>" log/symphony.log*
+
+# 5) Focus on stuck/retry signals
+rg -n "Issue stalled|scheduling retry|turn_timeout|turn_failed|Claude session failed|Claude session ended with error" log/symphony.log*
+```
+
+## Investigation Flow
+
+1. Locate the ticket slice:
+    - Search by `issue_identifier=<KEY>`.
+    - If noise is high, add `issue_id=<UUID>`.
+2. Establish timeline:
+    - Identify first `Claude session started ... session_id=...`.
+    - Follow with `Claude session completed`, `ended with error`, or worker exit
+      lines.
+3. Classify the problem:
+    - Stall loop: `Issue stalled ... restarting with backoff`.
+    - App-server startup: `Claude session failed ...`.
+    - Turn execution failure: `turn_failed`, `turn_cancelled`, `turn_timeout`, or
+      `ended with error`.
+    - Worker crash: `Agent task exited ... reason=...`.
+4. Validate scope:
+    - Check whether failures are isolated to one issue/session or repeating across
+      multiple tickets.
+5. Capture evidence:
+    - Save key log lines with timestamps, `issue_identifier`, `issue_id`, and
+      `session_id`.
+    - Record probable root cause and the exact failing stage.
+
+## Reading Claude Session Logs
+
+In Symphony, Claude session diagnostics are emitted into `log/symphony.log` and
+keyed by `session_id`. Read them as a lifecycle:
+
+1. `Claude session started ... session_id=...`
+2. Session stream/lifecycle events for the same `session_id`
+3. Terminal event:
+    - `Claude session completed ...`, or
+    - `Claude session ended with error ...`, or
+    - `Issue stalled ... restarting with backoff`
+
+For one specific session investigation, keep the trace narrow:
+
+1. Capture one `session_id` for the ticket.
+2. Build a timestamped slice for only that session:
+    - `rg -n "session_id=<thread>-<turn>" log/symphony.log*`
+3. Mark the exact failing stage:
+    - Startup failure before stream events (`Claude session failed ...`).
+    - Turn/runtime failure after stream events (`turn_*` / `ended with error`).
+    - Stall recovery (`Issue stalled ... restarting with backoff`).
+4. Pair findings with `issue_identifier` and `issue_id` from nearby lines to
+   confirm you are not mixing concurrent retries.
+
+Always pair session findings with `issue_identifier`/`issue_id` to avoid mixing
+concurrent runs.
+
+## Notes
+
+- Prefer `rg` over `grep` for speed on large logs.
+- Check rotated logs (`log/symphony.log*`) before concluding data is missing.
+- If required context fields are missing in new log statements, align with
+  `elixir/docs/logging.md` conventions.

--- a/.claude/skills/land/SKILL.md
+++ b/.claude/skills/land/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: land
+description:
+  Land a PR by monitoring conflicts, resolving them, waiting for checks, and
+  squash-merging when green; use when asked to land, merge, or shepherd a PR to
+  completion.
+---
+
+# Land
+
+## Goals
+
+- Ensure the PR is conflict-free with main.
+- Keep CI green and fix failures when they occur.
+- Squash-merge the PR once checks pass.
+- Do not yield to the user until the PR is merged; keep the watcher loop running
+  unless blocked.
+- No need to delete remote branches after merge; the repo auto-deletes head
+  branches.
+
+## Preconditions
+
+- `gh` CLI is authenticated.
+- You are on the PR branch with a clean working tree.
+
+## Steps
+
+1. Locate the PR for the current branch.
+2. Confirm the full gauntlet is green locally before any push.
+3. If the working tree has uncommitted changes, commit with the `commit` skill
+   and push with the `push` skill before proceeding.
+4. Check mergeability and conflicts against main.
+5. If conflicts exist, use the `pull` skill to fetch/merge `origin/main` and
+   resolve conflicts, then use the `push` skill to publish the updated branch.
+6. Ensure Claude review comments (if present) are acknowledged and any required
+   fixes are handled before merging.
+7. Watch checks until complete.
+8. If checks fail, pull logs, fix the issue, commit with the `commit` skill,
+   push with the `push` skill, and re-run checks.
+9. When all checks are green and review feedback is addressed, squash-merge and
+   delete the branch using the PR title/body for the merge subject/body.
+10. **Context guard:** Before implementing review feedback, confirm it does not
+    conflict with the user’s stated intent or task context. If it conflicts,
+    respond inline with a justification and ask the user before changing code.
+11. **Pushback template:** When disagreeing, reply inline with: acknowledge +
+    rationale + offer alternative.
+12. **Ambiguity gate:** When ambiguity blocks progress, use the clarification
+    flow (assign PR to current GH user, mention them, wait for response). Do not
+    implement until ambiguity is resolved.
+    - If you are confident you know better than the reviewer, you may proceed
+      without asking the user, but reply inline with your rationale.
+13. **Per-comment mode:** For each review comment, choose one of: accept,
+    clarify, or push back. Reply inline (or in the issue thread for Claude
+    reviews) stating the mode before changing code.
+14. **Reply before change:** Always respond with intended action before pushing
+    code changes (inline for review comments, issue thread for Claude reviews).
+
+## Commands
+
+```
+# Ensure branch and PR context
+branch=$(git branch --show-current)
+pr_number=$(gh pr view --json number -q .number)
+pr_title=$(gh pr view --json title -q .title)
+pr_body=$(gh pr view --json body -q .body)
+
+# Check mergeability and conflicts
+mergeable=$(gh pr view --json mergeable -q .mergeable)
+
+if [ "$mergeable" = "CONFLICTING" ]; then
+  # Run the `pull` skill to handle fetch + merge + conflict resolution.
+  # Then run the `push` skill to publish the updated branch.
+fi
+
+# Preferred: use the Async Watch Helper below. The manual loop is a fallback
+# when Python cannot run or the helper script is unavailable.
+# Wait for review feedback: Claude reviews arrive as issue comments that start
+# with "## Claude Review — <persona>". Treat them like reviewer feedback: reply
+# with a `[claude]` issue comment acknowledging the findings and whether you're
+# addressing or deferring them.
+while true; do
+  gh api repos/{owner}/{repo}/issues/"$pr_number"/comments \
+    --jq '.[] | select(.body | startswith("## Claude Review")) | .id' | rg -q '.' \
+    && break
+  sleep 10
+done
+
+# Watch checks
+if ! gh pr checks --watch; then
+  gh pr checks
+  # Identify failing run and inspect logs
+  # gh run list --branch "$branch"
+  # gh run view <run-id> --log
+  exit 1
+fi
+
+# Squash-merge (remote branches auto-delete on merge in this repo)
+gh pr merge --squash --subject "$pr_title" --body "$pr_body"
+```
+
+## Async Watch Helper
+
+Preferred: use the asyncio watcher to monitor review comments, CI, and head
+updates in parallel:
+
+```
+python3 .claude/skills/land/land_watch.py
+```
+
+Exit codes:
+
+- 2: Review comments detected (address feedback)
+- 3: CI checks failed
+- 4: PR head updated (autofix commit detected)
+
+## Failure Handling
+
+- If checks fail, pull details with `gh pr checks` and `gh run view --log`, then
+  fix locally, commit with the `commit` skill, push with the `push` skill, and
+  re-run the watch.
+- Use judgment to identify flaky failures. If a failure is a flake (e.g., a
+  timeout on only one platform), you may proceed without fixing it.
+- If CI pushes an auto-fix commit (authored by GitHub Actions), it does not
+  trigger a fresh CI run. Detect the updated PR head, pull locally, merge
+  `origin/main` if needed, add a real author commit, and force-push to retrigger
+  CI, then restart the checks loop.
+- If all jobs fail with corrupted pnpm lockfile errors on the merge commit, the
+  remediation is to fetch latest `origin/main`, merge, force-push, and rerun CI.
+- If mergeability is `UNKNOWN`, wait and re-check.
+- Do not merge while review comments (human or Claude review) are outstanding.
+- Claude review jobs retry on failure and are non-blocking; use the presence of
+  `## Claude Review — <persona>` issue comments (not job status) as the signal
+  that review feedback is available.
+- Do not enable auto-merge; this repo has no required checks so auto-merge can
+  skip tests.
+- If the remote PR branch advanced due to your own prior force-push or merge,
+  avoid redundant merges; re-run the formatter locally if needed and
+  `git push --force-with-lease`.
+
+## Review Handling
+
+- Claude reviews now arrive as issue comments posted by GitHub Actions. They
+  start with `## Claude Review — <persona>` and include the reviewer’s
+  methodology + guardrails used. Treat these as feedback that must be
+  acknowledged before merge.
+- Human review comments are blocking and must be addressed (responded to and
+  resolved) before requesting a new review or merging.
+- If multiple reviewers comment in the same thread, respond to each comment
+  (batching is fine) before closing the thread.
+- Fetch review comments via `gh api` and reply with a prefixed comment.
+- Use review comment endpoints (not issue comments) to find inline feedback:
+  - List PR review comments:
+    ```
+    gh api repos/{owner}/{repo}/pulls/<pr_number>/comments
+    ```
+  - PR issue comments (top-level discussion):
+    ```
+    gh api repos/{owner}/{repo}/issues/<pr_number>/comments
+    ```
+  - Reply to a specific review comment:
+    ```
+    gh api -X POST /repos/{owner}/{repo}/pulls/<pr_number>/comments \
+      -f body='[claude] <response>' -F in_reply_to=<comment_id>
+    ```
+- `in_reply_to` must be the numeric review comment id (e.g., `2710521800`), not
+  the GraphQL node id (e.g., `PRRC_...`), and the endpoint must include the PR
+  number (`/pulls/<pr_number>/comments`).
+- If GraphQL review reply mutation is forbidden, use REST.
+- A 404 on reply typically means the wrong endpoint (missing PR number) or
+  insufficient scope; verify by listing comments first.
+- All GitHub comments generated by this agent must be prefixed with `[claude]`.
+- For Claude review issue comments, reply in the issue thread (not a review
+  thread) with `[claude]` and state whether you will address the feedback now or
+  defer it (include rationale).
+- If feedback requires changes:
+  - For inline review comments (human), reply with intended fixes
+    (`[claude] ...`) **as an inline reply to the original review comment** using
+    the review comment endpoint and `in_reply_to` (do not use issue comments for
+    this).
+  - Implement fixes, commit, push.
+  - Reply with the fix details and commit sha (`[claude] ...`) in the same place
+    you acknowledged the feedback (issue comment for Claude reviews, inline reply
+    for review comments).
+  - The land watcher treats Claude review issue comments as unresolved until a
+    newer `[claude]` issue comment is posted acknowledging the findings.
+- Only request a new Claude review when you need a rerun (e.g., after new
+  commits). Do not request one without changes since the last review.
+  - Before requesting a new Claude review, re-run the land watcher and ensure
+    there are zero outstanding review comments (all have `[claude]` inline
+    replies).
+  - After pushing new commits, the Claude review workflow will rerun on PR
+    synchronization (or you can re-run the workflow manually). Post a concise
+    root-level summary comment so reviewers have the latest delta:
+    ```
+    [claude] Changes since last review:
+    - <short bullets of deltas>
+    Commits: <sha>, <sha>
+    Tests: <commands run>
+    ```
+  - Only request a new review if there is at least one new commit since the
+    previous request.
+  - Wait for the next Claude review comment before merging.
+
+## Scope + PR Metadata
+
+- The PR title and description should reflect the full scope of the change, not
+  just the most recent fix.
+- If review feedback expands scope, decide whether to include it now or defer
+  it. You can accept, defer, or decline feedback. If deferring or declining,
+  call it out in the root-level `[claude]` update with a brief reason (e.g.,
+  out-of-scope, conflicts with intent, unnecessary).
+- Correctness issues raised in review comments should be addressed. If you plan
+  to defer or decline a correctness concern, validate first and explain why the
+  concern does not apply.
+- Classify each review comment as one of: correctness, design, style,
+  clarification, scope.
+- For correctness feedback, provide concrete validation (test, log, or
+  reasoning) before closing it.
+- When accepting feedback, include a one-line rationale in the root-level
+  update.
+- When declining feedback, offer a brief alternative or follow-up trigger.
+- Prefer a single consolidated "review addressed" root-level comment after a
+  batch of fixes instead of many small updates.
+- For doc feedback, confirm the doc change matches behavior (no doc-only edits
+  to appease review).

--- a/.claude/skills/land/land_watch.py
+++ b/.claude/skills/land/land_watch.py
@@ -1,0 +1,621 @@
+#!/usr/bin/env python3
+import asyncio
+import json
+import random
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+POLL_SECONDS = 10
+CHECKS_APPEAR_TIMEOUT_SECONDS = 120
+CODEX_BOTS = {
+    "chatgpt-claude-connector[bot]",
+    "github-actions[bot]",
+    "claude-gc-app[bot]",
+    "app/claude-gc-app",
+}
+MAX_GH_RETRIES = 5
+BASE_GH_BACKOFF_SECONDS = 2
+
+
+@dataclass
+class PrInfo:
+    number: int
+    url: str
+    head_sha: str
+    mergeable: str | None
+    merge_state: str | None
+
+
+class RateLimitError(RuntimeError):
+    pass
+
+
+def is_rate_limit_error(error: str) -> bool:
+    return "HTTP 429" in error or "rate limit" in error.lower()
+
+
+async def run_gh(*args: str) -> str:
+    max_delay = BASE_GH_BACKOFF_SECONDS * (2 ** (MAX_GH_RETRIES - 1))
+    delay_seconds = BASE_GH_BACKOFF_SECONDS
+    last_error = "gh command failed"
+    for attempt in range(1, MAX_GH_RETRIES + 1):
+        proc = await asyncio.create_subprocess_exec(
+            "gh",
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        if proc.returncode == 0:
+            return stdout.decode()
+        error = stderr.decode().strip() or "gh command failed"
+        if not is_rate_limit_error(error):
+            raise RuntimeError(error)
+        last_error = error
+        if attempt >= MAX_GH_RETRIES:
+            break
+        jitter = random.uniform(0, delay_seconds)
+        await asyncio.sleep(min(delay_seconds + jitter, max_delay))
+        delay_seconds = min(delay_seconds * 2, max_delay)
+    raise RateLimitError(last_error)
+
+
+async def get_pr_info() -> PrInfo:
+    data = await run_gh(
+        "pr",
+        "view",
+        "--json",
+        "number,url,headRefOid,mergeable,mergeStateStatus",
+    )
+    parsed = json.loads(data)
+    return PrInfo(
+        number=parsed["number"],
+        url=parsed["url"],
+        head_sha=parsed["headRefOid"],
+        mergeable=parsed.get("mergeable"),
+        merge_state=parsed.get("mergeStateStatus"),
+    )
+
+
+async def get_paginated_list(endpoint: str) -> list[dict[str, Any]]:
+    page = 1
+    items: list[dict[str, Any]] = []
+    while True:
+        data = await run_gh(
+            "api",
+            "--method",
+            "GET",
+            endpoint,
+            "-f",
+            "per_page=100",
+            "-f",
+            f"page={page}",
+        )
+        batch = json.loads(data)
+        if not batch:
+            break
+        items.extend(batch)
+        page += 1
+    return items
+
+
+async def get_issue_comments(pr_number: int) -> list[dict[str, Any]]:
+    return await get_paginated_list(
+        f"repos/{{owner}}/{{repo}}/issues/{pr_number}/comments",
+    )
+
+
+async def get_review_comments(pr_number: int) -> list[dict[str, Any]]:
+    return await get_paginated_list(
+        f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/comments",
+    )
+
+
+async def get_reviews(pr_number: int) -> list[dict[str, Any]]:
+    page = 1
+    reviews: list[dict[str, Any]] = []
+    while True:
+        data = await run_gh(
+            "api",
+            "--method",
+            "GET",
+            f"repos/{{owner}}/{{repo}}/pulls/{pr_number}/reviews",
+            "-f",
+            "per_page=100",
+            "-f",
+            f"page={page}",
+        )
+        batch = json.loads(data)
+        if not batch:
+            break
+        reviews.extend(batch)
+        page += 1
+    return reviews
+
+
+async def get_check_runs(head_sha: str) -> list[dict[str, Any]]:
+    page = 1
+    check_runs: list[dict[str, Any]] = []
+    while True:
+        data = await run_gh(
+            "api",
+            "--method",
+            "GET",
+            f"repos/{{owner}}/{{repo}}/commits/{head_sha}/check-runs",
+            "-f",
+            "per_page=100",
+            "-f",
+            f"page={page}",
+        )
+        payload = json.loads(data)
+        batch = payload.get("check_runs", [])
+        if not batch:
+            break
+        check_runs.extend(batch)
+        total_count = payload.get("total_count")
+        if total_count is not None and len(check_runs) >= total_count:
+            break
+        page += 1
+    return check_runs
+
+
+def parse_time(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00")
+    return datetime.fromisoformat(normalized)
+
+
+CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")
+
+
+def sanitize_terminal_output(value: str) -> str:
+    return CONTROL_CHARS_RE.sub("", value)
+
+
+def check_timestamp(check: dict[str, Any]) -> datetime | None:
+    for key in ("completed_at", "started_at", "run_started_at", "created_at"):
+        value = check.get(key)
+        if value:
+            return parse_time(value)
+    return None
+
+
+def dedupe_check_runs(check_runs: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    latest_by_name: dict[str, dict[str, Any]] = {}
+    for check in check_runs:
+        name = check.get("name", "unknown")
+        timestamp = check_timestamp(check)
+        if name not in latest_by_name:
+            latest_by_name[name] = check
+            continue
+        existing = latest_by_name[name]
+        existing_timestamp = check_timestamp(existing)
+        if timestamp is None:
+            continue
+        if existing_timestamp is None or timestamp > existing_timestamp:
+            latest_by_name[name] = check
+    return list(latest_by_name.values())
+
+
+def summarize_checks(check_runs: list[dict[str, Any]]) -> tuple[bool, bool, list[str]]:
+    if not check_runs:
+        return True, False, ["no checks reported"]
+    check_runs = dedupe_check_runs(check_runs)
+    pending = False
+    failed = False
+    failures: list[str] = []
+    for check in check_runs:
+        status = check.get("status")
+        conclusion = check.get("conclusion")
+        name = check.get("name", "unknown")
+        if status != "completed":
+            pending = True
+            continue
+        if conclusion not in ("success", "skipped", "neutral"):
+            failed = True
+            failures.append(f"{name}: {conclusion}")
+    return pending, failed, failures
+
+
+def latest_review_request_at(comments: list[dict[str, Any]]) -> datetime | None:
+    latest: datetime | None = None
+    for comment in comments:
+        if is_claude_bot_user(comment.get("user", {})):
+            continue
+        body = comment.get("body") or ""
+        if "@claude review" not in body:
+            continue
+        timestamp = comment_time(comment)
+        if timestamp is None:
+            continue
+        if latest is None or timestamp > latest:
+            latest = timestamp
+    return latest
+
+
+def filter_claude_comments(
+    comments: list[dict[str, Any]],
+    review_requested_at: datetime | None,
+) -> list[dict[str, Any]]:
+    latest_claude_reply = latest_claude_reply_by_thread(comments)
+    latest_issue_ack = latest_claude_issue_reply_time(comments)
+    claude_comments = [c for c in comments if is_claude_bot_user(c.get("user", {}))]
+    filtered: list[dict[str, Any]] = []
+    for comment in claude_comments:
+        created_time = comment_time(comment)
+        if created_time is None:
+            continue
+        if review_requested_at is not None and created_time <= review_requested_at:
+            continue
+        is_threaded = bool(
+            comment.get("in_reply_to_id") or comment.get("pull_request_review_id")
+        )
+        if not is_threaded:
+            if latest_issue_ack is not None and created_time <= latest_issue_ack:
+                continue
+        else:
+            thread_root = thread_root_id(comment)
+            last_reply = None
+            if thread_root is not None:
+                last_reply = latest_claude_reply.get(thread_root)
+            if last_reply and last_reply > created_time:
+                continue
+        filtered.append(comment)
+    return filtered
+
+
+def is_claude_bot_user(user: dict[str, Any]) -> bool:
+    login = user.get("login") or ""
+    return login in CODEX_BOTS
+
+
+def is_bot_user(user: dict[str, Any]) -> bool:
+    login = user.get("login") or ""
+    if is_claude_bot_user(user):
+        return True
+    if user.get("type") == "Bot":
+        return True
+    return login.endswith("[bot]")
+
+
+def is_claude_reply_body(body: str) -> bool:
+    return body.startswith("[claude]")
+
+
+def is_claude_review_body(body: str) -> bool:
+    return body.startswith("## Claude Review")
+
+
+def latest_claude_issue_reply_time(
+    comments: list[dict[str, Any]],
+) -> datetime | None:
+    latest: datetime | None = None
+    for comment in comments:
+        body = (comment.get("body") or "").strip()
+        if not is_claude_reply_body(body):
+            continue
+        created_time = comment_time(comment)
+        if created_time is None:
+            continue
+        if latest is None or created_time > latest:
+            latest = created_time
+    return latest
+
+
+def filter_human_issue_comments(comments: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    latest_ack = latest_claude_issue_reply_time(comments)
+    filtered: list[dict[str, Any]] = []
+    for comment in comments:
+        if is_bot_user(comment.get("user", {})):
+            continue
+        body = (comment.get("body") or "").strip()
+        if is_claude_reply_body(body):
+            continue
+        if is_claude_review_body(body):
+            continue
+        if "@claude review" in body:
+            continue
+        created_time = comment_time(comment)
+        if (
+            latest_ack is not None
+            and created_time is not None
+            and created_time <= latest_ack
+        ):
+            continue
+        filtered.append(comment)
+    return filtered
+
+
+def filter_claude_review_issue_comments(
+    comments: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    latest_ack = latest_claude_issue_reply_time(comments)
+    filtered: list[dict[str, Any]] = []
+    for comment in comments:
+        body = (comment.get("body") or "").strip()
+        if not is_claude_review_body(body):
+            continue
+        created_time = comment_time(comment)
+        if (
+            latest_ack is not None
+            and created_time is not None
+            and created_time <= latest_ack
+        ):
+            continue
+        filtered.append(comment)
+    return filtered
+
+
+def thread_root_id(comment: dict[str, Any]) -> int | None:
+    return comment.get("in_reply_to_id") or comment.get("id")
+
+
+def comment_time(comment: dict[str, Any]) -> datetime | None:
+    timestamp = comment.get("updated_at") or comment.get("created_at")
+    if not timestamp:
+        return None
+    return parse_time(timestamp)
+
+
+def latest_claude_reply_by_thread(
+    comments: list[dict[str, Any]],
+) -> dict[int, datetime]:
+    latest: dict[int, datetime] = {}
+    for comment in comments:
+        body = (comment.get("body") or "").strip()
+        if not is_claude_reply_body(body):
+            continue
+        thread_root = thread_root_id(comment)
+        created_time = comment_time(comment)
+        if thread_root is None or created_time is None:
+            continue
+        existing = latest.get(thread_root)
+        if existing is None or created_time > existing:
+            latest[thread_root] = created_time
+    return latest
+
+
+def filter_human_review_comments(
+    comments: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    latest_claude_reply = latest_claude_reply_by_thread(comments)
+    filtered: list[dict[str, Any]] = []
+    for comment in comments:
+        if is_bot_user(comment.get("user", {})):
+            continue
+        body = (comment.get("body") or "").strip()
+        if is_claude_reply_body(body):
+            continue
+        thread_root = thread_root_id(comment)
+        created_time = comment_time(comment)
+        last_claude_reply = None
+        if thread_root is not None:
+            last_claude_reply = latest_claude_reply.get(thread_root)
+        if last_claude_reply and created_time and created_time <= last_claude_reply:
+            continue
+        filtered.append(comment)
+    return filtered
+
+
+def is_blocking_review(
+    review: dict[str, Any],
+    review_requested_at: datetime | None,
+) -> bool:
+    created_at = review.get("submitted_at") or review.get("created_at")
+    if not created_at:
+        return False
+    user_login = review.get("user", {}).get("login")
+    created_time = parse_time(created_at)
+    if (
+        user_login in CODEX_BOTS
+        and review_requested_at is not None
+        and created_time <= review_requested_at
+    ):
+        return False
+    body = (review.get("body") or "").strip()
+    state = review.get("state")
+    if user_login in CODEX_BOTS:
+        return state == "CHANGES_REQUESTED"
+    if body.startswith("[claude]") or state in ("APPROVED", "DISMISSED"):
+        return False
+    blocking = False
+    if body or state == "CHANGES_REQUESTED":
+        blocking = True
+    elif state == "COMMENTED":
+        blocking = False
+    elif state:
+        blocking = state not in ("APPROVED", "DISMISSED")
+    return blocking
+
+
+def review_timestamp(review: dict[str, Any]) -> datetime | None:
+    created_at = review.get("submitted_at") or review.get("created_at")
+    if not created_at:
+        return None
+    return parse_time(created_at)
+
+
+def dedupe_reviews(reviews: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    latest_by_user: dict[str, dict[str, Any]] = {}
+    for review in reviews:
+        user_login = review.get("user", {}).get("login")
+        if not user_login:
+            continue
+        timestamp = review_timestamp(review)
+        if user_login not in latest_by_user:
+            latest_by_user[user_login] = review
+            continue
+        existing = latest_by_user[user_login]
+        existing_timestamp = review_timestamp(existing)
+        if timestamp is None:
+            continue
+        if existing_timestamp is None or timestamp > existing_timestamp:
+            latest_by_user[user_login] = review
+    return list(latest_by_user.values())
+
+
+def filter_blocking_reviews(
+    reviews: list[dict[str, Any]],
+    review_requested_at: datetime | None,
+) -> list[dict[str, Any]]:
+    return [
+        review
+        for review in dedupe_reviews(reviews)
+        if is_blocking_review(review, review_requested_at)
+    ]
+
+
+def is_merge_conflicting(pr: PrInfo) -> bool:
+    return pr.mergeable == "CONFLICTING" or pr.merge_state == "DIRTY"
+
+
+async def fetch_review_context(
+    pr_number: int,
+) -> tuple[
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    list[dict[str, Any]],
+    datetime | None,
+]:
+    issue_comments = await get_issue_comments(pr_number)
+    review_request_at = latest_review_request_at(issue_comments)
+    review_comments = await get_review_comments(pr_number)
+    reviews = await get_reviews(pr_number)
+    return issue_comments, review_comments, reviews, review_request_at
+
+
+def raise_on_human_feedback(
+    issue_comments: list[dict[str, Any]],
+    review_comments: list[dict[str, Any]],
+    reviews: list[dict[str, Any]],
+    review_request_at: datetime | None,
+) -> None:
+    human_issue_comments = filter_human_issue_comments(issue_comments)
+    claude_review_comments = filter_claude_review_issue_comments(issue_comments)
+    human_review_comments = filter_human_review_comments(review_comments)
+    if human_issue_comments or human_review_comments or claude_review_comments:
+        print("Review comments detected. Address before merge.")
+        print(
+            "Reminder: decide whether feedback stays in scope; defer if needed "
+            "and note in your root-level update.",
+        )
+        raise SystemExit(2)
+    blocking_reviews = filter_blocking_reviews(reviews, review_request_at)
+    if blocking_reviews:
+        print("Review states/comments detected. Address before merge.")
+        print(
+            "Reminder: keep PR title/description aligned with the full scope "
+            "when changes expand.",
+        )
+        raise SystemExit(2)
+
+
+async def wait_for_claude(pr_number: int, checks_done: asyncio.Event) -> None:
+    print("Waiting for review feedback...", flush=True)
+    while True:
+        (
+            issue_comments,
+            review_comments,
+            reviews,
+            review_request_at,
+        ) = await fetch_review_context(pr_number)
+        bot_issue_comments = filter_claude_comments(issue_comments, review_request_at)
+        bot_review_comments = filter_claude_comments(review_comments, review_request_at)
+        bot_comments = bot_issue_comments + bot_review_comments
+        raise_on_human_feedback(
+            issue_comments,
+            review_comments,
+            reviews,
+            review_request_at,
+        )
+        if bot_comments:
+            latest = max(
+                bot_comments,
+                key=lambda comment: parse_time(comment["created_at"]),
+            )
+            body = sanitize_terminal_output(latest.get("body") or "").strip()
+            if body:
+                print("Claude left comments. Address feedback before merge.")
+                print(body)
+                raise SystemExit(2)
+        if checks_done.is_set():
+            return
+        await asyncio.sleep(POLL_SECONDS)
+
+
+async def wait_for_checks(head_sha: str, checks_done: asyncio.Event) -> None:
+    print("Waiting for CI checks...", flush=True)
+    empty_seconds = 0
+    while True:
+        check_runs = await get_check_runs(head_sha)
+        if not check_runs:
+            empty_seconds += POLL_SECONDS
+            if empty_seconds >= CHECKS_APPEAR_TIMEOUT_SECONDS:
+                print(
+                    "No checks detected after 120s; check CI configuration",
+                )
+                raise SystemExit(3)
+            await asyncio.sleep(POLL_SECONDS)
+            continue
+        empty_seconds = 0
+        pending, failed, failures = summarize_checks(check_runs)
+        if failed:
+            print("Checks failed:")
+            for failure in failures:
+                print(f"- {failure}")
+            raise SystemExit(3)
+        if not pending:
+            print("Checks passed")
+            checks_done.set()
+            return
+        await asyncio.sleep(POLL_SECONDS)
+
+
+async def watch_pr() -> None:
+    pr = await get_pr_info()
+    if is_merge_conflicting(pr):
+        print(
+            "PR has merge conflicts. Resolve/rebase against main and push before "
+            "running land_watch again.",
+        )
+        raise SystemExit(5)
+    head_sha = pr.head_sha
+    checks_done = asyncio.Event()
+    claude_task = asyncio.create_task(wait_for_claude(pr.number, checks_done))
+    checks_task = asyncio.create_task(wait_for_checks(head_sha, checks_done))
+
+    async def head_monitor() -> None:
+        while True:
+            current = await get_pr_info()
+            if is_merge_conflicting(current):
+                print(
+                    "PR has merge conflicts. Resolve/rebase against main and push "
+                    "before running land_watch again.",
+                )
+                raise SystemExit(5)
+            if current.head_sha != head_sha:
+                print("PR head updated; pull/amend/force-push to retrigger CI")
+                raise SystemExit(4)
+            await asyncio.sleep(POLL_SECONDS)
+
+    monitor_task = asyncio.create_task(head_monitor())
+    success_task = asyncio.gather(claude_task, checks_task)
+
+    done, pending = await asyncio.wait(
+        [monitor_task, success_task],
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+    for task in pending:
+        task.cancel()
+    for task in done:
+        exc = task.exception()
+        if exc:
+            raise exc
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(watch_pr())
+    except SystemExit as exc:
+        raise SystemExit(exc.code) from None

--- a/.claude/skills/linear/SKILL.md
+++ b/.claude/skills/linear/SKILL.md
@@ -1,0 +1,388 @@
+---
+name: linear
+description: |
+  Use Symphony's `linear_graphql` client tool for raw Linear GraphQL
+  operations such as comment editing and upload flows.
+---
+
+# Linear GraphQL
+
+Use this skill for raw Linear GraphQL work during Symphony app-server sessions.
+
+## Primary tool
+
+Use the `linear_graphql` client tool exposed by Symphony's app-server session.
+It reuses Symphony's configured Linear auth for the session.
+
+Tool input:
+
+```json
+{
+  "query": "query or mutation document",
+  "variables": {
+    "optional": "graphql variables object"
+  }
+}
+```
+
+Tool behavior:
+
+- Send one GraphQL operation per tool call.
+- Treat a top-level `errors` array as a failed GraphQL operation even if the
+  tool call itself completed.
+- Keep queries/mutations narrowly scoped; ask only for the fields you need.
+
+## Discovering unfamiliar operations
+
+When you need an unfamiliar mutation, input type, or object field, use targeted
+introspection through `linear_graphql`.
+
+List mutation names:
+
+```graphql
+query ListMutations {
+  __type(name: "Mutation") {
+    fields {
+      name
+    }
+  }
+}
+```
+
+Inspect a specific input object:
+
+```graphql
+query CommentCreateInputShape {
+  __type(name: "CommentCreateInput") {
+    inputFields {
+      name
+      type {
+        kind
+        name
+        ofType {
+          kind
+          name
+        }
+      }
+    }
+  }
+}
+```
+
+## Common workflows
+
+### Query an issue by key, identifier, or id
+
+Use these progressively:
+
+- Start with `issue(id: $key)` when you have a ticket key such as `MT-686`.
+- Fall back to `issues(filter: ...)` when you need identifier search semantics.
+- Once you have the internal issue id, prefer `issue(id: $id)` for narrower reads.
+
+Lookup by issue key:
+
+```graphql
+query IssueByKey($key: String!) {
+  issue(id: $key) {
+    id
+    identifier
+    title
+    state {
+      id
+      name
+      type
+    }
+    project {
+      id
+      name
+    }
+    branchName
+    url
+    description
+    updatedAt
+    links {
+      nodes {
+        id
+        url
+        title
+      }
+    }
+  }
+}
+```
+
+Lookup by identifier filter:
+
+```graphql
+query IssueByIdentifier($identifier: String!) {
+  issues(filter: { identifier: { eq: $identifier } }, first: 1) {
+    nodes {
+      id
+      identifier
+      title
+      state {
+        id
+        name
+        type
+      }
+      project {
+        id
+        name
+      }
+      branchName
+      url
+      description
+      updatedAt
+    }
+  }
+}
+```
+
+Resolve a key to an internal id:
+
+```graphql
+query IssueByIdOrKey($id: String!) {
+  issue(id: $id) {
+    id
+    identifier
+    title
+  }
+}
+```
+
+Read the issue once the internal id is known:
+
+```graphql
+query IssueDetails($id: String!) {
+  issue(id: $id) {
+    id
+    identifier
+    title
+    url
+    description
+    state {
+      id
+      name
+      type
+    }
+    project {
+      id
+      name
+    }
+    attachments {
+      nodes {
+        id
+        title
+        url
+        sourceType
+      }
+    }
+  }
+}
+```
+
+### Query team workflow states for an issue
+
+Use this before changing issue state when you need the exact `stateId`:
+
+```graphql
+query IssueTeamStates($id: String!) {
+  issue(id: $id) {
+    id
+    team {
+      id
+      key
+      name
+      states {
+        nodes {
+          id
+          name
+          type
+        }
+      }
+    }
+  }
+}
+```
+
+### Edit an existing comment
+
+Use `commentUpdate` through `linear_graphql`:
+
+```graphql
+mutation UpdateComment($id: String!, $body: String!) {
+  commentUpdate(id: $id, input: { body: $body }) {
+    success
+    comment {
+      id
+      body
+    }
+  }
+}
+```
+
+### Create a comment
+
+Use `commentCreate` through `linear_graphql`:
+
+```graphql
+mutation CreateComment($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) {
+    success
+    comment {
+      id
+      url
+    }
+  }
+}
+```
+
+### Move an issue to a different state
+
+Use `issueUpdate` with the destination `stateId`:
+
+```graphql
+mutation MoveIssueToState($id: String!, $stateId: String!) {
+  issueUpdate(id: $id, input: { stateId: $stateId }) {
+    success
+    issue {
+      id
+      identifier
+      state {
+        id
+        name
+      }
+    }
+  }
+}
+```
+
+### Attach a GitHub PR to an issue
+
+Use the GitHub-specific attachment mutation when linking a PR:
+
+```graphql
+mutation AttachGitHubPR($issueId: String!, $url: String!, $title: String) {
+  attachmentLinkGitHubPR(
+    issueId: $issueId
+    url: $url
+    title: $title
+    linkKind: links
+  ) {
+    success
+    attachment {
+      id
+      title
+      url
+    }
+  }
+}
+```
+
+If you only need a plain URL attachment and do not care about GitHub-specific
+link metadata, use:
+
+```graphql
+mutation AttachURL($issueId: String!, $url: String!, $title: String) {
+  attachmentLinkURL(issueId: $issueId, url: $url, title: $title) {
+    success
+    attachment {
+      id
+      title
+      url
+    }
+  }
+}
+```
+
+### Introspection patterns used during schema discovery
+
+Use these when the exact field or mutation shape is unclear:
+
+```graphql
+query QueryFields {
+  __type(name: "Query") {
+    fields {
+      name
+    }
+  }
+}
+```
+
+```graphql
+query IssueFieldArgs {
+  __type(name: "Query") {
+    fields {
+      name
+      args {
+        name
+        type {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Upload a video to a comment
+
+Do this in three steps:
+
+1. Call `linear_graphql` with `fileUpload` to get `uploadUrl`, `assetUrl`, and
+   any required upload headers.
+2. Upload the local file bytes to `uploadUrl` with `curl -X PUT` and the exact
+   headers returned by `fileUpload`.
+3. Call `linear_graphql` again with `commentCreate` (or `commentUpdate`) and
+   include the resulting `assetUrl` in the comment body.
+
+Useful mutations:
+
+```graphql
+mutation FileUpload(
+  $filename: String!
+  $contentType: String!
+  $size: Int!
+  $makePublic: Boolean
+) {
+  fileUpload(
+    filename: $filename
+    contentType: $contentType
+    size: $size
+    makePublic: $makePublic
+  ) {
+    success
+    uploadFile {
+      uploadUrl
+      assetUrl
+      headers {
+        key
+        value
+      }
+    }
+  }
+}
+```
+
+## Usage rules
+
+- Use `linear_graphql` for comment edits, uploads, and ad-hoc Linear API
+  queries.
+- Prefer the narrowest issue lookup that matches what you already know:
+  key -> identifier search -> internal id.
+- For state transitions, fetch team states first and use the exact `stateId`
+  instead of hardcoding names inside mutations.
+- Prefer `attachmentLinkGitHubPR` over a generic URL attachment when linking a
+  GitHub PR to a Linear issue.
+- Do not introduce new raw-token shell helpers for GraphQL access.
+- If you need shell work for uploads, only use it for signed upload URLs
+  returned by `fileUpload`; those URLs already carry the needed authorization.

--- a/.claude/skills/pull/SKILL.md
+++ b/.claude/skills/pull/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: pull
+description:
+  Pull latest origin/main into the current local branch and resolve merge
+  conflicts (aka update-branch). Use when Claude needs to sync a feature branch
+  with origin, perform a merge-based update (not rebase), and guide conflict
+  resolution best practices.
+---
+
+# Pull
+
+## Workflow
+
+1. Verify git status is clean or commit/stash changes before merging.
+2. Ensure rerere is enabled locally:
+   - `git config rerere.enabled true`
+   - `git config rerere.autoupdate true`
+3. Confirm remotes and branches:
+   - Ensure the `origin` remote exists.
+   - Ensure the current branch is the one to receive the merge.
+4. Fetch latest refs:
+   - `git fetch origin`
+5. Sync the remote feature branch first:
+   - `git pull --ff-only origin $(git branch --show-current)`
+   - This pulls branch updates made remotely (for example, a GitHub auto-commit)
+     before merging `origin/main`.
+6. Merge in order:
+   - Prefer `git -c merge.conflictstyle=zdiff3 merge origin/main` for clearer
+     conflict context.
+7. If conflicts appear, resolve them (see conflict guidance below), then:
+   - `git add <files>`
+   - `git commit` (or `git merge --continue` if the merge is paused)
+8. Verify with project checks (follow repo policy in `AGENTS.md`).
+9. Summarize the merge:
+   - Call out the most challenging conflicts/files and how they were resolved.
+   - Note any assumptions or follow-ups.
+
+## Conflict Resolution Guidance (Best Practices)
+
+- Inspect context before editing:
+  - Use `git status` to list conflicted files.
+  - Use `git diff` or `git diff --merge` to see conflict hunks.
+  - Use `git diff :1:path/to/file :2:path/to/file` and
+    `git diff :1:path/to/file :3:path/to/file` to compare base vs ours/theirs
+    for a file-level view of intent.
+  - With `merge.conflictstyle=zdiff3`, conflict markers include:
+    - `<<<<<<<` ours, `|||||||` base, `=======` split, `>>>>>>>` theirs.
+    - Matching lines near the start/end are trimmed out of the conflict region,
+      so focus on the differing core.
+  - Summarize the intent of both changes, decide the semantically correct
+    outcome, then edit:
+    - State what each side is trying to achieve (bug fix, refactor, rename,
+      behavior change).
+    - Identify the shared goal, if any, and whether one side supersedes the
+      other.
+    - Decide the final behavior first; only then craft the code to match that
+      decision.
+    - Prefer preserving invariants, API contracts, and user-visible behavior
+      unless the conflict clearly indicates a deliberate change.
+  - Open files and understand intent on both sides before choosing a resolution.
+- Prefer minimal, intention-preserving edits:
+  - Keep behavior consistent with the branch’s purpose.
+  - Avoid accidental deletions or silent behavior changes.
+- Resolve one file at a time and rerun tests after each logical batch.
+- Use `ours/theirs` only when you are certain one side should win entirely.
+- For complex conflicts, search for related files or definitions to align with
+  the rest of the codebase.
+- For generated files, resolve non-generated conflicts first, then regenerate:
+  - Prefer resolving source files and handwritten logic before touching
+    generated artifacts.
+  - Run the CLI/tooling command that produced the generated file to recreate it
+    cleanly, then stage the regenerated output.
+- For import conflicts where intent is unclear, accept both sides first:
+  - Keep all candidate imports temporarily, finish the merge, then run lint/type
+    checks to remove unused or incorrect imports safely.
+- After resolving, ensure no conflict markers remain:
+  - `git diff --check`
+- When unsure, note assumptions and ask for confirmation before finalizing the
+  merge.
+
+## When To Ask The User (Keep To A Minimum)
+
+Do not ask for input unless there is no safe, reversible alternative. Prefer
+making a best-effort decision, documenting the rationale, and proceeding.
+
+Ask the user only when:
+
+- The correct resolution depends on product intent or behavior not inferable
+  from code, tests, or nearby documentation.
+- The conflict crosses a user-visible contract, API surface, or migration where
+  choosing incorrectly could break external consumers.
+- A conflict requires selecting between two mutually exclusive designs with
+  equivalent technical merit and no clear local signal.
+- The merge introduces data loss, schema changes, or irreversible side effects
+  without an obvious safe default.
+- The branch is not the intended target, or the remote/branch names do not exist
+  and cannot be determined locally.
+
+Otherwise, proceed with the merge, explain the decision briefly in notes, and
+leave a clear, reviewable commit history.

--- a/.claude/skills/push/SKILL.md
+++ b/.claude/skills/push/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: push
+description:
+  Push current branch changes to origin and create or update the corresponding
+  pull request; use when asked to push, publish updates, or create pull request.
+---
+
+# Push
+
+## Prerequisites
+
+- `gh` CLI is installed and available in `PATH`.
+- `gh auth status` succeeds for GitHub operations in this repo.
+
+## Goals
+
+- Push current branch changes to `origin` safely.
+- Create a PR if none exists for the branch, otherwise update the existing PR.
+- Keep branch history clean when remote has moved.
+
+## Related Skills
+
+- `pull`: use this when push is rejected or sync is not clean (non-fast-forward,
+  merge conflict risk, or stale branch).
+
+## Steps
+
+1. Identify current branch and confirm remote state.
+2. Run local validation (`make -C elixir all`) before pushing.
+3. Push branch to `origin` with upstream tracking if needed, using whatever
+   remote URL is already configured.
+4. If push is not clean/rejected:
+   - If the failure is a non-fast-forward or sync problem, run the `pull`
+     skill to merge `origin/main`, resolve conflicts, and rerun validation.
+   - Push again; use `--force-with-lease` only when history was rewritten.
+   - If the failure is due to auth, permissions, or workflow restrictions on
+     the configured remote, stop and surface the exact error instead of
+     rewriting remotes or switching protocols as a workaround.
+
+5. Ensure a PR exists for the branch:
+   - If no PR exists, create one.
+   - If a PR exists and is open, update it.
+   - If branch is tied to a closed/merged PR, create a new branch + PR.
+   - Write a proper PR title that clearly describes the change outcome
+   - For branch updates, explicitly reconsider whether current PR title still
+     matches the latest scope; update it if it no longer does.
+6. Write/update PR body explicitly using `.github/pull_request_template.md`:
+   - Fill every section with concrete content for this change.
+   - Replace all placeholder comments (`<!-- ... -->`).
+   - Keep bullets/checkboxes where template expects them.
+   - If PR already exists, refresh body content so it reflects the total PR
+     scope (all intended work on the branch), not just the newest commits,
+     including newly added work, removed work, or changed approach.
+   - Do not reuse stale description text from earlier iterations.
+7. Validate PR body with `mix pr_body.check` and fix all reported issues.
+8. Reply with the PR URL from `gh pr view`.
+
+## Commands
+
+```sh
+# Identify branch
+branch=$(git branch --show-current)
+
+# Minimal validation gate
+make -C elixir all
+
+# Initial push: respect the current origin remote.
+git push -u origin HEAD
+
+# If that failed because the remote moved, use the pull skill. After
+# pull-skill resolution and re-validation, retry the normal push:
+git push -u origin HEAD
+
+# If the configured remote rejects the push for auth, permissions, or workflow
+# restrictions, stop and surface the exact error.
+
+# Only if history was rewritten locally:
+git push --force-with-lease origin HEAD
+
+# Ensure a PR exists (create only if missing)
+pr_state=$(gh pr view --json state -q .state 2>/dev/null || true)
+if [ "$pr_state" = "MERGED" ] || [ "$pr_state" = "CLOSED" ]; then
+  echo "Current branch is tied to a closed PR; create a new branch + PR." >&2
+  exit 1
+fi
+
+# Write a clear, human-friendly title that summarizes the shipped change.
+pr_title="<clear PR title written for this change>"
+if [ -z "$pr_state" ]; then
+  gh pr create --title "$pr_title"
+else
+  # Reconsider title on every branch update; edit if scope shifted.
+  gh pr edit --title "$pr_title"
+fi
+
+# Write/edit PR body to match .github/pull_request_template.md before validation.
+# Example workflow:
+# 1) open the template and draft body content for this PR
+# 2) gh pr edit --body-file /tmp/pr_body.md
+# 3) for branch updates, re-check that title/body still match current diff
+
+tmp_pr_body=$(mktemp)
+gh pr view --json body -q .body > "$tmp_pr_body"
+(cd elixir && mix pr_body.check --file "$tmp_pr_body")
+rm -f "$tmp_pr_body"
+
+# Show PR URL for the reply
+gh pr view --json url -q .url
+```
+
+## Notes
+
+- Do not use `--force`; only use `--force-with-lease` as the last resort.
+- Distinguish sync problems from remote auth/permission problems:
+  - Use the `pull` skill for non-fast-forward or stale-branch issues.
+  - Surface auth, permissions, or workflow restrictions directly instead of
+    changing remotes or protocols.

--- a/.claude/worktree_init.sh
+++ b/.claude/worktree_init.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+project_root="$repo_root/elixir"
+
+if ! command -v mise >/dev/null 2>&1; then
+  echo "mise is required. Install it from https://mise.jdx.dev/getting-started.html" >&2
+  exit 1
+fi
+
+cd "$project_root"
+mise trust
+
+make setup

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ work instead of supervising coding agents.
 
 [![Symphony demo video preview](.github/media/symphony-demo-poster.jpg)](.github/media/symphony-demo.mp4)
 
-_In this [demo video](.github/media/symphony-demo.mp4), Symphony monitors a Linear board for work and spawns agents to handle the tasks. The agents complete the tasks and provide proof of work: CI status, PR review feedback, complexity analysis, and walkthrough videos. When accepted, the agents land the PR safely. Engineers do not need to supervise Codex; they can manage the work at a higher level._
+_In this [demo video](.github/media/symphony-demo.mp4), Symphony monitors a Linear board for work and spawns agents to handle the tasks. The agents complete the tasks and provide proof of work: CI status, PR review feedback, complexity analysis, and walkthrough videos. When accepted, the agents land the PR safely. Engineers do not need to supervise Claude; they can manage the work at a higher level._
 
 > [!WARNING]
 > Symphony is a low-key engineering preview for testing in trusted environments.

--- a/SPEC.md
+++ b/SPEC.md
@@ -231,13 +231,13 @@ Fields:
 - `session_id` (string, `<thread_id>-<turn_id>`)
 - `thread_id` (string)
 - `turn_id` (string)
-- `agent_app_server_pid` (string or null)
-- `last_agent_event` (string/enum or null)
-- `last_agent_timestamp` (timestamp or null)
-- `last_agent_message` (summarized payload)
-- `agent_input_tokens` (integer)
-- `agent_output_tokens` (integer)
-- `agent_total_tokens` (integer)
+- `claude_app_server_pid` (string or null)
+- `last_claude_event` (string/enum or null)
+- `last_claude_timestamp` (timestamp or null)
+- `last_claude_message` (summarized payload)
+- `claude_input_tokens` (integer)
+- `claude_output_tokens` (integer)
+- `claude_total_tokens` (integer)
 - `last_reported_input_tokens` (integer)
 - `last_reported_output_tokens` (integer)
 - `last_reported_total_tokens` (integer)
@@ -269,8 +269,8 @@ Fields:
 - `claimed` (set of issue IDs reserved/running/retrying)
 - `retry_attempts` (map `issue_id -> RetryEntry`)
 - `completed` (set of issue IDs; bookkeeping only, not dispatch gating)
-- `agent_totals` (aggregate tokens + runtime seconds)
-- `agent_rate_limits` (latest rate-limit snapshot from agent events)
+- `claude_totals` (aggregate tokens + runtime seconds)
+- `claude_rate_limits` (latest rate-limit snapshot from agent events)
 
 ### 4.2 Stable Identifiers and Normalization Rules
 
@@ -409,6 +409,12 @@ Fields:
 
 Fields:
 
+- `command` (string shell command, OPTIONAL)
+  - Overrides the app-server command.
+  - Default: `claude-app-server --listen stdio://`.
+- `permission_mode` (string)
+  - Default: `dontAsk`
+  - Sent to Claude as the app-server permission mode.
 - `max_concurrent_agents` (integer)
   - Default: `10`
   - Changes SHOULD be re-applied at runtime and affect subsequent dispatch decisions.
@@ -428,23 +434,12 @@ Fields:
 
 Fields:
 
-For Claude-owned config values such as `approval_policy`, `thread_sandbox`, and
-`turn_sandbox_policy`, supported values are defined by the targeted Claude app-server version.
-Implementors SHOULD treat them as pass-through Claude config values rather than relying on a
-hand-maintained enum in this spec. To inspect the installed Claude schema, consult the relevant
-definitions referenced by `v2/ThreadStartParams.json` and `v2/TurnStartParams.json`. Implementations
-MAY validate these fields locally if they want stricter startup checks.
-
 - `command` (string shell command)
-  - Default: `claude app-server`
+  - Default: `claude-app-server --listen stdio://`
   - The runtime launches this command via `bash -lc` in the workspace directory.
   - The launched process MUST speak a compatible app-server protocol over stdio.
-- `approval_policy` (Claude `AskForApproval` value)
-  - Default: implementation-defined.
-- `thread_sandbox` (Claude `SandboxMode` value)
-  - Default: implementation-defined.
-- `turn_sandbox_policy` (Claude `SandboxPolicy` value)
-  - Default: implementation-defined.
+- `permission_mode` (Claude permission mode string)
+  - Default: `dontAsk`.
 - `turn_timeout_ms` (integer)
   - Default: `3600000` (1 hour)
 - `read_timeout_ms` (integer)
@@ -586,10 +581,8 @@ not require recognizing or validating extension fields unless that extension is 
 - `agent.max_turns`: integer, default `20`
 - `agent.max_retry_backoff_ms`: integer, default `300000` (5m)
 - `agent.max_concurrent_agents_by_state`: map of positive integers, default `{}`
-- `claude.command`: shell command string, default `claude app-server`
-- `claude.approval_policy`: Claude `AskForApproval` value, default implementation-defined
-- `claude.thread_sandbox`: Claude `SandboxMode` value, default implementation-defined
-- `claude.turn_sandbox_policy`: Claude `SandboxPolicy` value, default implementation-defined
+- `claude.command`: shell command string, default `claude-app-server --listen stdio://`
+- `claude.permission_mode`: Claude permission mode, default `dontAsk`
 - `claude.turn_timeout_ms`: integer, default `3600000`
 - `claude.read_timeout_ms`: integer, default `5000`
 - `claude.stall_timeout_ms`: integer, default `300000`
@@ -672,7 +665,7 @@ Distinct terminal reasons are important because retry logic and logs differ.
   - Update aggregate runtime totals.
   - Schedule exponential-backoff retry.
 
-- `Agent Update Event`
+- `Claude Update Event`
   - Update live session fields, token counters, and rate limits.
 
 - `Retry Timer Fired`
@@ -782,7 +775,7 @@ Reconciliation runs every tick and has two parts.
 Part A: Stall detection
 
 - For each running issue, compute `elapsed_ms` since:
-  - `last_agent_timestamp` if any event has been seen, else
+  - `last_claude_timestamp` if any event has been seen, else
   - `started_at`
 - If `elapsed_ms > claude.stall_timeout_ms`, terminate the worker and queue a retry.
 - If `stall_timeout_ms <= 0`, skip stall detection entirely.
@@ -922,16 +915,22 @@ Protocol source of truth:
 
 Subprocess launch parameters:
 
-- Command: `claude.command`
-- Invocation: `bash -lc <claude.command>`
+- Command: the resolved provider command
+- Invocation: `bash -lc <resolved provider command>`
 - Working directory: workspace path
-- Transport/framing: the protocol transport required by the targeted Claude app-server version
+- Transport/framing: stdio JSON-RPC using the selected provider's compatible app-server
 
 Notes:
 
-- The default command is `claude app-server`.
-- Approval policy, sandbox policy, cwd, prompt input, and OPTIONAL tool declarations are supplied
-  using fields supported by the targeted Codex app-server version.
+- Claude uses `claude-app-server --listen stdio://` by default.
+- `claude-app-server` is installed from the `logitropic/claude-app-server` npm GitHub dependency
+  and is separate from Claude Code's `claude` binary.
+- For Claude, Symphony sends Claude-compatible `thread/start` and `turn/start` payloads with cwd,
+  text input, title, and permission mode; it omits sandbox fields.
+- Claude provider execution requires both `logitropic/claude-app-server` and
+  `@anthropic-ai/claude-code`. Claude Code supplies local authentication and runtime/tool setup.
+  Claude dynamic tool injection is not guaranteed unless the Claude app-server implements compatible
+  calls.
 
 RECOMMENDED additional process settings:
 
@@ -939,7 +938,7 @@ RECOMMENDED additional process settings:
 
 ### 10.2 Session Startup Responsibilities
 
-Reference: (Claude app-server integration; contact Anthropic for documentation)
+Reference: https://github.com/logitropic/claude-app-server
 
 Startup MUST follow the targeted Claude app-server contract. Symphony additionally requires the
 client to:
@@ -952,8 +951,8 @@ client to:
 - Start the first turn with the rendered issue prompt.
 - Start later in-worker continuation turns on the same live thread with continuation guidance rather
   than resending the original issue prompt.
-- Supply the implementation's documented approval and sandbox policy using fields supported by the
-  targeted protocol.
+- Supply the implementation's documented permission mode using fields supported by the targeted
+  protocol.
 - Include issue-identifying metadata, such as `<issue.identifier>: <issue.title>`, when the targeted
   protocol supports turn or session titles.
 - Advertise implemented client-side tools using the targeted protocol.
@@ -998,7 +997,7 @@ include:
 
 - `event` (enum/string)
 - `timestamp` (UTC timestamp)
-- `agent_app_server_pid` (if available)
+- `claude_app_server_pid` (if available)
 - OPTIONAL `usage` map (token counts)
 - payload fields as needed
 
@@ -1103,7 +1102,7 @@ Timeouts:
 
 Error mapping (RECOMMENDED normalized categories):
 
-- `agent_not_found`
+- `claude_not_found`
 - `invalid_workspace_cwd`
 - `response_timeout`
 - `turn_timeout`
@@ -1280,7 +1279,7 @@ SHOULD return:
 - `running` (list of running session rows)
 - each running row SHOULD include `turn_count`
 - `retrying` (list of retry queue rows)
-- `agent_totals`
+- `claude_totals`
   - `input_tokens`
   - `output_tokens`
   - `total_tokens`
@@ -1422,7 +1421,7 @@ Minimum endpoints:
           "error": "no available orchestrator slots"
         }
       ],
-      "agent_totals": {
+      "claude_totals": {
         "input_tokens": 5000,
         "output_tokens": 2400,
         "total_tokens": 7400,
@@ -1465,10 +1464,10 @@ Minimum endpoints:
       },
       "retry": null,
       "logs": {
-        "agent_session_logs": [
+        "claude_session_logs": [
           {
             "label": "latest",
-            "path": "/var/log/symphony/agent/MT-649/latest.log",
+            "path": "/var/log/symphony/claude/MT-649/latest.log",
             "url": null
           }
         ]
@@ -1646,7 +1645,7 @@ Implications:
 
 ### 15.5 Harness Hardening Guidance
 
-Running Codex agents against repositories, issue trackers, and other inputs that can contain
+Running Claude agents against repositories, issue trackers, and other inputs that can contain
 sensitive data or externally-controlled content can be dangerous. A permissive deployment can lead
 to data leaks, destructive mutations, or full machine compromise if the agent is induced to execute
 harmful commands or use overly-powerful integrations.
@@ -1689,8 +1688,8 @@ function start_service():
     claimed: set(),
     retry_attempts: {},
     completed: set(),
-    agent_totals: {input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
-    agent_rate_limits: null
+    claude_totals: {input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+    claude_rate_limits: null
   }
 
   validation = validate_dispatch_config()
@@ -1782,13 +1781,13 @@ function dispatch_issue(issue, state, attempt):
     identifier: issue.identifier,
     issue,
     session_id: null,
-    agent_app_server_pid: null,
-    last_agent_message: null,
-    last_agent_event: null,
-    last_agent_timestamp: null,
-    agent_input_tokens: 0,
-    agent_output_tokens: 0,
-    agent_total_tokens: 0,
+    claude_app_server_pid: null,
+    last_claude_message: null,
+    last_claude_event: null,
+    last_claude_timestamp: null,
+    claude_input_tokens: 0,
+    claude_output_tokens: 0,
+    claude_total_tokens: 0,
     last_reported_input_tokens: 0,
     last_reported_output_tokens: 0,
     last_reported_total_tokens: 0,
@@ -1831,7 +1830,7 @@ function run_agent_attempt(issue, attempt, orchestrator_channel):
       session=session,
       prompt=prompt,
       issue=issue,
-      on_message=(msg) -> send(orchestrator_channel, {agent_update, issue.id, msg})
+      on_message=(msg) -> send(orchestrator_channel, {claude_update, issue.id, msg})
     )
 
     if turn_result failed:
@@ -1943,7 +1942,7 @@ Unless otherwise noted, Sections 17.1 through 17.7 are `Core Conformance`. Bulle
 - `tracker.api_key` works (including `$VAR` indirection)
 - `$VAR` resolution works for tracker API key and path values
 - `~` path expansion works
-- `claude.command` is preserved as a shell command string
+- `claude.command` is preserved as a shell command string and defaults to `claude-app-server --listen stdio://`
 - Per-state concurrency override map normalizes state names and ignores invalid values
 - Prompt template renders `issue` and `attempt`
 - Prompt rendering fails on unknown variables (strict mode)
@@ -2076,7 +2075,8 @@ Use the same validation profiles as Section 17:
 - Workspace lifecycle hooks (`after_create`, `before_run`, `after_run`, `before_remove`)
 - Hook timeout config (`hooks.timeout_ms`, default `60000`)
 - Coding-agent app-server subprocess client with JSON line protocol
-- Claude launch command config (`claude.command`, default `claude app-server`)
+- Runtime dependencies on `logitropic/claude-app-server` and `@anthropic-ai/claude-code`
+- Claude launch command config (`claude.command`, default `claude-app-server --listen stdio://`)
 - Strict prompt rendering with `issue` and `attempt` variables
 - Exponential retry queue with continuation retries after normal exit
 - Configurable retry backoff cap (`agent.max_retry_backoff_ms`, default 5m)

--- a/elixir/AGENTS.md
+++ b/elixir/AGENTS.md
@@ -1,6 +1,6 @@
 # Symphony Elixir
 
-This directory contains the Elixir agent orchestration service that polls Linear, creates per-issue workspaces, and runs Codex in app-server mode.
+This directory contains the Elixir agent orchestration service that polls Linear, creates per-issue workspaces, and runs Claude in app-server mode.
 
 ## Environment
 
@@ -19,7 +19,7 @@ This directory contains the Elixir agent orchestration service that polls Linear
     change where practical so the spec stays current.
 - Prefer adding config access through `SymphonyElixir.Config` instead of ad-hoc env reads.
 - Workspace safety is critical:
-  - Never run Codex turn cwd in source repo.
+  - Never run Claude turn cwd in source repo.
   - Workspaces must stay under configured workspace root.
 - Orchestrator behavior is stateful and concurrency-sensitive; preserve retry, reconciliation, and cleanup semantics.
 - Follow `docs/logging.md` for logging conventions and required issue/session context fields.

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -15,10 +15,10 @@ This directory contains the current Elixir/OTP implementation of Symphony, based
 
 1. Polls Linear for candidate work
 2. Creates a workspace per issue
-3. Launches Codex in [App Server mode](https://developers.openai.com/codex/app-server/) inside the
+3. Launches Claude through [`claude-app-server`](https://github.com/logitropic/claude-app-server) inside the
    workspace
-4. Sends a workflow prompt to Codex
-5. Keeps Codex working on the issue until the work is done
+4. Sends a workflow prompt to Claude
+5. Keeps Claude working on the issue until the work is done
 
 During app-server sessions, Symphony also serves a client-side `linear_graphql` tool so that repo
 skills can make raw Linear GraphQL calls.
@@ -81,7 +81,7 @@ Optional flags:
 - `--port` also starts the Phoenix observability service (default: disabled)
 
 The `WORKFLOW.md` file uses YAML front matter for configuration, plus a Markdown body used as the
-Codex session prompt.
+agent session prompt.
 
 Minimal example:
 
@@ -98,8 +98,8 @@ hooks:
 agent:
   max_concurrent_agents: 10
   max_turns: 20
-codex:
-  command: codex app-server
+claude:
+  command: claude-app-server --listen stdio://
 ---
 
 You are working on a Linear issue {{ issue.identifier }}.
@@ -110,16 +110,12 @@ Title: {{ issue.title }} Body: {{ issue.description }}
 Notes:
 
 - If a value is missing, defaults are used.
-- Safer Codex defaults are used when policy fields are omitted:
-  - `codex.approval_policy` defaults to `{"reject":{"sandbox_approval":true,"rules":true,"mcp_elicitations":true}}`
-  - `codex.thread_sandbox` defaults to `workspace-write`
-  - `codex.turn_sandbox_policy` defaults to a `workspaceWrite` policy rooted at the current issue workspace
-- Supported `codex.approval_policy` values depend on the targeted Codex app-server version. In the current local Codex schema, string values include `untrusted`, `on-failure`, `on-request`, and `never`, and object-form `reject` is also supported.
-- Supported `codex.thread_sandbox` values: `read-only`, `workspace-write`, `danger-full-access`.
-- When `codex.turn_sandbox_policy` is set explicitly, Symphony passes the map through to Codex
-  unchanged. Compatibility then depends on the targeted Codex app-server version rather than local
-  Symphony validation.
-- `agent.max_turns` caps how many back-to-back Codex turns Symphony will run in a single agent
+- `claude.command` overrides the app-server command. The fallback is `claude-app-server --listen stdio://`.
+- `claude.permission_mode` controls the permission mode sent to the app-server. The default is
+  `dontAsk`.
+- `claude.turn_timeout_ms`, `claude.read_timeout_ms`, and `claude.stall_timeout_ms` control runtime
+  turn handling and stream timeouts.
+- `agent.max_turns` caps how many back-to-back agent turns Symphony will run in a single agent
   invocation when a turn completes normally but the issue is still in an active state. Default: `20`.
 - If the Markdown body is blank, Symphony uses a default prompt template that includes the issue
   identifier, title, and body.
@@ -130,8 +126,8 @@ Notes:
 - `tracker.api_key` reads from `LINEAR_API_KEY` when unset or when value is `$LINEAR_API_KEY`.
 - For path values, `~` is expanded to the home directory.
 - For env-backed path values, use `$VAR`. `workspace.root` resolves `$VAR` before path handling,
-  while `codex.command` stays a shell command string and any `$VAR` expansion there happens in the
-  launched shell.
+  while app-server command strings stay shell commands and any `$VAR` expansion there happens in
+  the launched shell.
 
 ```yaml
 tracker:
@@ -141,9 +137,28 @@ workspace:
 hooks:
   after_create: |
     git clone --depth 1 "$SOURCE_REPO_URL" .
-codex:
-  command: "$CODEX_BIN --config 'model=\"gpt-5.5\"' app-server"
+claude:
+  command: "$CLAUDE_APP_SERVER_BIN --listen stdio://"
 ```
+
+Claude command examples:
+
+```yaml
+claude:
+  command: claude-app-server --listen stdio://
+```
+
+```yaml
+claude:
+  command: "/Users/hieunguyen/Coding/logitropic/claude-app-server/target/release/claude-app-server --listen stdio://"
+```
+
+Claude requires both `logitropic/claude-app-server` and Claude Code. The
+`logitropic/claude-app-server` npm GitHub dependency provides the `claude-app-server` binary that
+Symphony launches, while `@anthropic-ai/claude-code` provides the `claude` binary, local
+authentication, and Claude runtime/tool setup used by the app server. Symphony currently reuses its
+stdio JSON-RPC client loop but does not guarantee Claude dynamic tool injection unless
+`claude-app-server` implements those calls.
 
 - If `WORKFLOW.md` is missing or has invalid YAML at startup, Symphony does not boot.
 - If a later reload fails, Symphony keeps running with the last known good workflow and logs the
@@ -165,7 +180,7 @@ The observability UI now runs on a minimal Phoenix stack:
 - `lib/`: application code and Mix tasks
 - `test/`: ExUnit coverage for runtime behavior
 - `WORKFLOW.md`: in-repo workflow contract used by local runs
-- `../.codex/`: repository-local Codex skills and setup helpers
+- `../.claude/`: repository-local Claude skills and setup helpers
 
 ## Testing
 
@@ -174,7 +189,7 @@ make all
 ```
 
 Run the real external end-to-end test only when you want Symphony to create disposable Linear
-resources and launch a real `codex app-server` session:
+resources and launch a real `claude-app-server --listen stdio://` session:
 
 ```bash
 cd elixir
@@ -193,14 +208,14 @@ Optional environment variables:
 
 If `SYMPHONY_LIVE_SSH_WORKER_HOSTS` is unset, the SSH scenario uses `docker compose` to start two
 disposable SSH workers on `localhost:<port>`. The live test generates a temporary SSH keypair,
-mounts the host `~/.codex/auth.json` into each worker, verifies that Symphony can talk to them
+mounts the host `~/.claude/auth.json` into each worker, verifies that Symphony can talk to them
 over real SSH, then runs the same orchestration flow against those worker addresses. This keeps
 the transport representative without depending on long-lived external machines.
 
 Set `SYMPHONY_LIVE_SSH_WORKER_HOSTS` if you want `make e2e` to target real SSH hosts instead.
 
 The live test creates a temporary Linear project and issue, writes a temporary `WORKFLOW.md`, runs
-a real agent turn, verifies the workspace side effect, requires Codex to comment on and close the
+a real agent turn, verifies the workspace side effect, requires Claude to comment on and close the
 Linear issue, then marks the project completed so the run remains visible in Linear.
 
 ## FAQ
@@ -213,7 +228,7 @@ actively running subagents, which is very useful during development.
 
 ### What's the easiest way to set this up for my own codebase?
 
-Launch `codex` in your repo, give it the URL to the Symphony repo, and ask it to set things up for
+Launch `claude` in your repo, give it the URL to the Symphony repo, and ask it to set things up for
 you.
 
 ## License

--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -28,12 +28,12 @@ hooks:
 agent:
   max_concurrent_agents: 10
   max_turns: 20
-codex:
-  command: codex --config shell_environment_policy.inherit=all --config 'model="gpt-5.5"' --config model_reasoning_effort=xhigh app-server
-  approval_policy: never
-  thread_sandbox: workspace-write
-  turn_sandbox_policy:
-    type: workspaceWrite
+claude:
+  command: claude-app-server --listen stdio://
+  permission_mode: bypassPermissions
+  read_timeout_ms: 30000
+  turn_timeout_ms: 600000
+  stall_timeout_ms: 120000
 ---
 
 You are working on a Linear ticket `{{ issue.identifier }}`
@@ -99,7 +99,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
 - `commit`: produce clean, logical commits during implementation.
 - `push`: keep remote branch current and publish updates.
 - `pull`: keep branch updated with latest `origin/main` before handoff.
-- `land`: when ticket reaches `Merging`, explicitly open and follow `.codex/skills/land/SKILL.md`, which includes the `land` loop.
+- `land`: when ticket reaches `Merging`, use the repository's land workflow and merge instructions.
 
 ## Status map
 
@@ -122,7 +122,7 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
      - If PR is already attached, start by reviewing all open PR comments and deciding required changes vs explicit pushback responses.
    - `In Progress` -> continue execution flow from current scratchpad comment.
    - `Human Review` -> wait and poll for decision/review updates.
-   - `Merging` -> on entry, open and follow `.codex/skills/land/SKILL.md`; do not call `gh pr merge` directly.
+   - `Merging` -> on entry, follow the repository's land workflow; do not call `gh pr merge` directly.
    - `Rework` -> run rework flow.
    - `Done` -> do nothing and shut down.
 4. Check whether a PR already exists for the current branch and whether it is closed.
@@ -130,14 +130,14 @@ The agent should be able to talk to Linear, either via a configured Linear MCP s
    - Create a fresh branch from `origin/main` and restart execution flow as a new attempt.
 5. For `Todo` tickets, do startup sequencing in this exact order:
    - `update_issue(..., state: "In Progress")`
-   - find/create `## Codex Workpad` bootstrap comment
+   - find/create `## Claude Workpad` bootstrap comment
    - only then begin analysis/planning/implementation work.
 6. Add a short comment if state and issue content are inconsistent, then proceed with the safest flow.
 
 ## Step 1: Start/continue execution (Todo or In Progress)
 
 1.  Find or create a single persistent scratchpad comment for the issue:
-    - Search existing comments for a marker header: `## Codex Workpad`.
+    - Search existing comments for a marker header: `## Claude Workpad`.
     - Ignore resolved comments while searching; only active/unresolved comments are eligible to be reused as the live workpad.
     - If found, reuse that comment; do not create a new workpad comment.
     - If not found, create one workpad comment and use it for all updates.
@@ -244,7 +244,7 @@ Use this only when completion is blocked by missing required tools or missing au
 2. Poll for updates as needed, including GitHub PR review comments from humans and bots.
 3. If review feedback requires changes, move the issue to `Rework` and follow the rework flow.
 4. If approved, human moves the issue to `Merging`.
-5. When the issue is in `Merging`, open and follow `.codex/skills/land/SKILL.md`, then run the `land` skill in a loop until the PR is merged. Do not call `gh pr merge` directly.
+5. When the issue is in `Merging`, run the land workflow in a loop until the PR is merged. Do not call `gh pr merge` directly.
 6. After merge is complete, move the issue to `Done`.
 
 ## Step 4: Rework handling
@@ -252,11 +252,11 @@ Use this only when completion is blocked by missing required tools or missing au
 1. Treat `Rework` as a full approach reset, not incremental patching.
 2. Re-read the full issue body and all human comments; explicitly identify what will be done differently this attempt.
 3. Close the existing PR tied to the issue.
-4. Remove the existing `## Codex Workpad` comment from the issue.
+4. Remove the existing `## Claude Workpad` comment from the issue.
 5. Create a fresh branch from `origin/main`.
 6. Start over from the normal kickoff flow:
    - If current issue state is `Todo`, move it to `In Progress`; otherwise keep the current state.
-   - Create a new bootstrap `## Codex Workpad` comment.
+   - Create a new bootstrap `## Claude Workpad` comment.
    - Build a fresh plan/checklist and execute end-to-end.
 
 ## Completion bar before Human Review
@@ -275,7 +275,7 @@ Use this only when completion is blocked by missing required tools or missing au
 - For closed/merged branch PRs, create a new branch from `origin/main` and restart from reproduction/planning as if starting fresh.
 - If issue state is `Backlog`, do not modify it; wait for human to move to `Todo`.
 - Do not edit the issue body/description for planning or progress tracking.
-- Use exactly one persistent workpad comment (`## Codex Workpad`) per issue.
+- Use exactly one persistent workpad comment (`## Claude Workpad`) per issue.
 - If comment editing is unavailable in-session, use the update script. Only report blocked if both MCP editing and script-based editing are unavailable.
 - Temporary proof edits are allowed only for local verification and must be reverted before commit.
 - If out-of-scope improvements are found, create a separate Backlog issue rather
@@ -294,7 +294,7 @@ Use this only when completion is blocked by missing required tools or missing au
 Use this exact structure for the persistent workpad comment and keep it updated in place throughout execution:
 
 ````md
-## Codex Workpad
+## Claude Workpad
 
 ```text
 <hostname>:<abs-path>@<short-sha>

--- a/elixir/docs/logging.md
+++ b/elixir/docs/logging.md
@@ -1,6 +1,6 @@
 # Logging Best Practices
 
-This guide defines logging conventions for Symphony so Codex can diagnose failures quickly.
+This guide defines logging conventions for Symphony so Claude can diagnose failures quickly.
 
 ## Goals
 
@@ -15,9 +15,9 @@ When logging issue-related work, include both identifiers:
 - `issue_id`: Linear internal UUID (stable foreign key).
 - `issue_identifier`: human ticket key (for example `MT-620`).
 
-When logging Codex execution lifecycle events, include:
+When logging Claude execution lifecycle events, include:
 
-- `session_id`: combined Codex thread/turn identifier.
+- `session_id`: combined Claude thread/turn identifier.
 
 ## Message Design
 
@@ -30,11 +30,11 @@ When logging Codex execution lifecycle events, include:
 
 - `AgentRunner`: log start/completion/failure with issue context, plus `session_id` when known.
 - `Orchestrator`: log dispatch, retry, terminal/non-active transitions, and worker exits with issue context. Include `session_id` whenever running-entry data has it.
-- `Codex.AppServer`: log session start/completion/error with issue context and `session_id`.
+- `Claude.AppServer`: log session start/completion/error with issue context and `session_id`.
 
 ## Checklist For New Logs
 
 - Is this event tied to a Linear issue? Include `issue_id` and `issue_identifier`.
-- Is this event tied to a Codex session? Include `session_id`.
+- Is this event tied to a Claude session? Include `session_id`.
 - Is the failure reason present and concise?
 - Is the message format consistent with existing lifecycle logs?

--- a/elixir/docs/token_accounting.md
+++ b/elixir/docs/token_accounting.md
@@ -1,8 +1,8 @@
-# Codex Token Accounting
+# Claude Token Accounting
 
-This document explains how Codex reports token usage through the app-server protocol and how Symphony should account for it.
+This document explains how Claude reports token usage through the app-server protocol and how Symphony should account for it.
 
-It is based on the current Codex source in `codex-rs`, especially:
+It is based on the current Claude source in `claude-rs`, especially:
 
 - `app-server/README.md`
 - `protocol/src/protocol.rs`
@@ -21,7 +21,7 @@ It is based on the current Codex source in `codex-rs`, especially:
 
 ## Primary Source Semantics
 
-Codex defines `TokenUsageInfo` like this:
+Claude defines `TokenUsageInfo` like this:
 
 ```rust
 pub struct TokenUsageInfo {
@@ -45,13 +45,13 @@ That gives the core semantics:
 - `last_token_usage`: the newest chunk of usage that was just added
 - `total_token_usage`: the accumulated total after adding that chunk
 
-This is the most important accounting rule in the Codex source.
+This is the most important accounting rule in the Claude source.
 
 ## Event Types
 
-### `codex/event/token_count`
+### `claude/event/token_count`
 
-Codex core emits token count events containing `TokenUsageInfo`.
+Claude core emits token count events containing `TokenUsageInfo`.
 
 These events can carry:
 
@@ -147,7 +147,7 @@ Important consequence:
 
 ### Generic `usage`
 
-Codex uses the word `usage` in multiple places.
+Claude uses the word `usage` in multiple places.
 
 That does not mean all `usage` maps have the same semantics.
 
@@ -193,7 +193,7 @@ Use these only when:
 
 `model_context_window` is not spend. It is the model's context limit.
 
-Codex also has logic that can "fill to context window", which sets:
+Claude also has logic that can "fill to context window", which sets:
 
 - `total_token_usage.total_tokens = context_window`
 - `last_token_usage.total_tokens = delta`
@@ -204,7 +204,7 @@ For Symphony, `model_context_window` should be displayed or logged separately fr
 
 ## Recommended Accounting Strategy For Symphony
 
-Track usage per active Codex thread.
+Track usage per active Claude thread.
 
 For each thread, keep:
 
@@ -253,7 +253,7 @@ If you misclassify a per-turn `usage` payload as an absolute thread total, later
 - Prefer `thread/tokenUsage/updated` for live reporting.
 - Treat `tokenUsage.total` as authoritative for thread totals.
 - Key accounting by `thread_id`, not just issue id.
-- Expect one thread to span multiple turns when Symphony reuses a live Codex thread.
+- Expect one thread to span multiple turns when Symphony reuses a live Claude thread.
 
 ### Do not
 
@@ -266,7 +266,7 @@ If you misclassify a per-turn `usage` payload as an absolute thread total, later
 
 When reading raw app-server events:
 
-- `codex/event/token_count`
+- `claude/event/token_count`
   - useful if you are inspecting nested `info.total_token_usage`
 - `thread/tokenUsage/updated`
   - best source for live dashboard and API totals
@@ -275,7 +275,7 @@ When reading raw app-server events:
 
 ## Why `total_token_usage` Is The Durable Choice
 
-Codex itself consistently prefers cumulative totals when it needs durable state:
+Claude itself consistently prefers cumulative totals when it needs durable state:
 
 - the state extractor stores `info.total_token_usage.total_tokens`
 - the exec event processor caches the last `total_token_usage` and uses that on turn completion
@@ -289,7 +289,7 @@ That is a strong signal for Symphony:
 
 If Symphony documents token reporting externally, the contract should be:
 
-- Live token totals come from Codex thread-scoped cumulative usage.
+- Live token totals come from Claude thread-scoped cumulative usage.
 - Incremental usage may also be emitted, but Symphony does not use it for totals.
 - Turn-completed usage is event-specific and should not be assumed to be a fresh additive increment.
 - Reporting is thread-based, and multiple turns can occur on one thread.

--- a/elixir/lib/symphony_elixir/agent_runner.ex
+++ b/elixir/lib/symphony_elixir/agent_runner.ex
@@ -4,17 +4,19 @@ defmodule SymphonyElixir.AgentRunner do
   """
 
   require Logger
+  alias SymphonyElixir.Claude.AppServer
   alias SymphonyElixir.{Config, Linear.Issue, PromptBuilder, Tracker, Workspace}
 
   @type worker_host :: String.t() | nil
 
   @spec run(map(), pid() | nil, keyword()) :: :ok | no_return()
-  def run(issue, _update_recipient \\ nil, opts \\ []) do
+  def run(issue, claude_update_recipient \\ nil, opts \\ []) do
+    # The orchestrator owns host retries so one worker lifetime never hops machines.
     worker_host = selected_worker_host(Keyword.get(opts, :worker_host), Config.settings!().worker.ssh_hosts)
 
     Logger.info("Starting agent run for #{issue_context(issue)} worker_host=#{worker_host_for_log(worker_host)}")
 
-    case run_on_worker_host(issue, opts, worker_host) do
+    case run_on_worker_host(issue, claude_update_recipient, opts, worker_host) do
       :ok ->
         :ok
 
@@ -24,14 +26,16 @@ defmodule SymphonyElixir.AgentRunner do
     end
   end
 
-  defp run_on_worker_host(issue, opts, worker_host) do
+  defp run_on_worker_host(issue, claude_update_recipient, opts, worker_host) do
     Logger.info("Starting worker attempt for #{issue_context(issue)} worker_host=#{worker_host_for_log(worker_host)}")
 
     case Workspace.create_for_issue(issue, worker_host) do
       {:ok, workspace} ->
+        send_worker_runtime_info(claude_update_recipient, issue, worker_host, workspace)
+
         try do
           with :ok <- Workspace.run_before_run_hook(workspace, issue, worker_host) do
-            run_agent_turns(workspace, issue, opts, worker_host)
+            run_claude_turns(workspace, issue, claude_update_recipient, opts, worker_host)
           end
         after
           Workspace.run_after_run_hook(workspace, issue, worker_host)
@@ -42,41 +46,87 @@ defmodule SymphonyElixir.AgentRunner do
     end
   end
 
-  defp run_agent_turns(workspace, issue, opts, worker_host) do
+  defp claude_message_handler(recipient, issue) do
+    fn message ->
+      send_claude_update(recipient, issue, message)
+    end
+  end
+
+  defp send_claude_update(recipient, %Issue{id: issue_id}, message)
+       when is_binary(issue_id) and is_pid(recipient) do
+    send(recipient, {:claude_worker_update, issue_id, message})
+    :ok
+  end
+
+  defp send_claude_update(_recipient, _issue, _message), do: :ok
+
+  defp send_worker_runtime_info(recipient, %Issue{id: issue_id}, worker_host, workspace)
+       when is_binary(issue_id) and is_pid(recipient) and is_binary(workspace) do
+    send(
+      recipient,
+      {:worker_runtime_info, issue_id,
+       %{
+         worker_host: worker_host,
+         workspace_path: workspace
+       }}
+    )
+
+    :ok
+  end
+
+  defp send_worker_runtime_info(_recipient, _issue, _worker_host, _workspace), do: :ok
+
+  defp run_claude_turns(workspace, issue, claude_update_recipient, opts, worker_host) do
     max_turns = Keyword.get(opts, :max_turns, Config.settings!().agent.max_turns)
     issue_state_fetcher = Keyword.get(opts, :issue_state_fetcher, &Tracker.fetch_issue_states_by_ids/1)
 
-    do_run_agent_turns(workspace, issue, opts, issue_state_fetcher, 1, max_turns)
+    with {:ok, session} <- AppServer.start_session(workspace, worker_host: worker_host) do
+      try do
+        do_run_claude_turns(session, workspace, issue, claude_update_recipient, opts, issue_state_fetcher, 1, max_turns)
+      after
+        AppServer.stop_session(session)
+      end
+    end
   end
 
-  defp do_run_agent_turns(workspace, issue, opts, issue_state_fetcher, turn_number, max_turns) do
+  defp do_run_claude_turns(app_session, workspace, issue, claude_update_recipient, opts, issue_state_fetcher, turn_number, max_turns) do
     prompt = build_turn_prompt(issue, opts, turn_number, max_turns)
 
-    Logger.info("Agent turn started for #{issue_context(issue)} turn=#{turn_number}/#{max_turns}")
+    with {:ok, turn_session} <-
+           AppServer.run_turn(
+             app_session,
+             prompt,
+             issue,
+             on_message: claude_message_handler(claude_update_recipient, issue)
+           ) do
+      Logger.info("Completed agent run for #{issue_context(issue)} session_id=#{turn_session[:session_id]} workspace=#{workspace} turn=#{turn_number}/#{max_turns}")
 
-    case continue_with_issue?(issue, issue_state_fetcher) do
-      {:continue, refreshed_issue} when turn_number < max_turns ->
-        Logger.info("Continuing agent run for #{issue_context(refreshed_issue)} after normal turn completion turn=#{turn_number}/#{max_turns}")
+      case continue_with_issue?(issue, issue_state_fetcher) do
+        {:continue, refreshed_issue} when turn_number < max_turns ->
+          Logger.info("Continuing agent run for #{issue_context(refreshed_issue)} after normal turn completion turn=#{turn_number}/#{max_turns}")
 
-        do_run_agent_turns(
-          workspace,
-          refreshed_issue,
-          opts,
-          issue_state_fetcher,
-          turn_number + 1,
-          max_turns
-        )
+          do_run_claude_turns(
+            app_session,
+            workspace,
+            refreshed_issue,
+            claude_update_recipient,
+            opts,
+            issue_state_fetcher,
+            turn_number + 1,
+            max_turns
+          )
 
-      {:continue, refreshed_issue} ->
-        Logger.info("Reached agent.max_turns for #{issue_context(refreshed_issue)} with issue still active; returning control to orchestrator")
+        {:continue, refreshed_issue} ->
+          Logger.info("Reached agent.max_turns for #{issue_context(refreshed_issue)} with issue still active; returning control to orchestrator")
 
-        :ok
+          :ok
 
-      {:done, _refreshed_issue} ->
-        :ok
+        {:done, _refreshed_issue} ->
+          :ok
 
-      {:error, reason} ->
-        {:error, reason}
+        {:error, reason} ->
+          {:error, reason}
+      end
     end
   end
 
@@ -86,7 +136,7 @@ defmodule SymphonyElixir.AgentRunner do
     """
     Continuation guidance:
 
-    - The previous agent turn completed normally, but the Linear issue is still in an active state.
+    - The previous Claude turn completed normally, but the Linear issue is still in an active state.
     - This is continuation turn ##{turn_number} of #{max_turns} for the current agent run.
     - Resume from the current workspace and workpad state instead of restarting from scratch.
     - The original task instructions and prior turn context are already present in this thread, so do not restate them before acting.

--- a/elixir/lib/symphony_elixir/claude/app_server.ex
+++ b/elixir/lib/symphony_elixir/claude/app_server.ex
@@ -1,0 +1,1092 @@
+defmodule SymphonyElixir.Claude.AppServer do
+  @moduledoc """
+  Minimal client for the Claude app-server JSON-RPC 2.0 stream over stdio.
+  """
+
+  require Logger
+  alias SymphonyElixir.{Claude.DynamicTool, Config, PathSafety, SSH}
+
+  @initialize_id 1
+  @thread_start_id 2
+  @turn_start_id 3
+  @port_line_bytes 1_048_576
+  @max_stream_log_bytes 1_000
+  @non_interactive_tool_input_answer "This is a non-interactive session. Operator input is unavailable."
+
+  @type session :: %{
+          port: port(),
+          metadata: map(),
+          auto_approve_requests: boolean(),
+          turn_timeout_ms: pos_integer(),
+          thread_id: String.t(),
+          workspace: Path.t(),
+          worker_host: String.t() | nil
+        }
+
+  @spec run(Path.t(), String.t(), map(), keyword()) :: {:ok, map()} | {:error, term()}
+  def run(workspace, prompt, issue, opts \\ []) do
+    with {:ok, session} <- start_session(workspace, opts) do
+      try do
+        run_turn(session, prompt, issue, opts)
+      after
+        stop_session(session)
+      end
+    end
+  end
+
+  @spec start_session(Path.t(), keyword()) :: {:ok, session()} | {:error, term()}
+  def start_session(workspace, opts \\ []) do
+    worker_host = Keyword.get(opts, :worker_host)
+
+    with {:ok, expanded_workspace} <- validate_workspace_cwd(workspace, worker_host),
+         {:ok, port} <- start_port(expanded_workspace, worker_host) do
+      metadata = port_metadata(port, worker_host)
+
+      with {:ok, session_settings} <- session_settings(expanded_workspace, worker_host),
+           {:ok, thread_id} <- do_start_session(port, expanded_workspace, session_settings) do
+        {:ok,
+         %{
+           port: port,
+           metadata: metadata,
+           auto_approve_requests: session_settings.permission_mode == "bypassPermissions",
+           turn_timeout_ms: session_settings.turn_timeout_ms,
+           thread_id: thread_id,
+           workspace: expanded_workspace,
+           worker_host: worker_host
+         }}
+      else
+        {:error, reason} ->
+          stop_port(port)
+          {:error, reason}
+      end
+    end
+  end
+
+  @spec run_turn(session(), String.t(), map(), keyword()) :: {:ok, map()} | {:error, term()}
+  def run_turn(
+        %{
+          port: port,
+          metadata: metadata,
+          auto_approve_requests: auto_approve_requests,
+          turn_timeout_ms: turn_timeout_ms,
+          thread_id: thread_id,
+          workspace: workspace
+        },
+        prompt,
+        issue,
+        opts \\ []
+      ) do
+    on_message = Keyword.get(opts, :on_message, &default_on_message/1)
+
+    tool_executor =
+      Keyword.get(opts, :tool_executor, fn tool, arguments ->
+        DynamicTool.execute(tool, arguments)
+      end)
+
+    case start_turn(port, thread_id, prompt, issue, workspace) do
+      {:ok, turn_id} ->
+        session_id = "#{thread_id}-#{turn_id}"
+        Logger.info("Claude session started for #{issue_context(issue)} session_id=#{session_id}")
+
+        emit_message(
+          on_message,
+          :session_started,
+          %{
+            session_id: session_id,
+            thread_id: thread_id,
+            turn_id: turn_id
+          },
+          metadata
+        )
+
+        case await_turn_completion(port, on_message, tool_executor, auto_approve_requests, turn_timeout_ms) do
+          {:ok, result} ->
+            Logger.info("Claude session completed for #{issue_context(issue)} session_id=#{session_id}")
+
+            {:ok,
+             %{
+               result: result,
+               session_id: session_id,
+               thread_id: thread_id,
+               turn_id: turn_id
+             }}
+
+          {:error, reason} ->
+            Logger.warning("Claude session ended with error for #{issue_context(issue)} session_id=#{session_id}: #{inspect(reason)}")
+
+            emit_message(
+              on_message,
+              :turn_ended_with_error,
+              %{
+                session_id: session_id,
+                reason: reason
+              },
+              metadata
+            )
+
+            {:error, reason}
+        end
+
+      {:error, reason} ->
+        Logger.error("Claude session failed for #{issue_context(issue)}: #{inspect(reason)}")
+        emit_message(on_message, :startup_failed, %{reason: reason}, metadata)
+        {:error, reason}
+    end
+  end
+
+  @spec stop_session(session()) :: :ok
+  def stop_session(%{port: port}) when is_port(port) do
+    stop_port(port)
+  end
+
+  defp validate_workspace_cwd(workspace, nil) when is_binary(workspace) do
+    expanded_workspace = Path.expand(workspace)
+    expanded_root = Path.expand(Config.settings!().workspace.root)
+    expanded_root_prefix = expanded_root <> "/"
+
+    with {:ok, canonical_workspace} <- PathSafety.canonicalize(expanded_workspace),
+         {:ok, canonical_root} <- PathSafety.canonicalize(expanded_root) do
+      canonical_root_prefix = canonical_root <> "/"
+
+      cond do
+        canonical_workspace == canonical_root ->
+          {:error, {:invalid_workspace_cwd, :workspace_root, canonical_workspace}}
+
+        String.starts_with?(canonical_workspace <> "/", canonical_root_prefix) ->
+          {:ok, canonical_workspace}
+
+        String.starts_with?(expanded_workspace <> "/", expanded_root_prefix) ->
+          {:error, {:invalid_workspace_cwd, :symlink_escape, expanded_workspace, canonical_root}}
+
+        true ->
+          {:error, {:invalid_workspace_cwd, :outside_workspace_root, canonical_workspace, canonical_root}}
+      end
+    else
+      {:error, {:path_canonicalize_failed, path, reason}} ->
+        {:error, {:invalid_workspace_cwd, :path_unreadable, path, reason}}
+    end
+  end
+
+  defp validate_workspace_cwd(workspace, worker_host)
+       when is_binary(workspace) and is_binary(worker_host) do
+    cond do
+      String.trim(workspace) == "" ->
+        {:error, {:invalid_workspace_cwd, :empty_remote_workspace, worker_host}}
+
+      String.contains?(workspace, ["\n", "\r", <<0>>]) ->
+        {:error, {:invalid_workspace_cwd, :invalid_remote_workspace, worker_host, workspace}}
+
+      true ->
+        {:ok, workspace}
+    end
+  end
+
+  defp start_port(workspace, nil) do
+    executable = System.find_executable("bash")
+
+    if is_nil(executable) do
+      {:error, :bash_not_found}
+    else
+      port =
+        Port.open(
+          {:spawn_executable, String.to_charlist(executable)},
+          [
+            :binary,
+            :exit_status,
+            :stderr_to_stdout,
+            args: [~c"-lc", String.to_charlist(Config.claude_command())],
+            cd: String.to_charlist(workspace),
+            line: @port_line_bytes
+          ]
+        )
+
+      {:ok, port}
+    end
+  end
+
+  defp start_port(workspace, worker_host) when is_binary(worker_host) do
+    remote_command = remote_launch_command(workspace)
+    SSH.start_port(worker_host, remote_command, line: @port_line_bytes)
+  end
+
+  defp remote_launch_command(workspace) when is_binary(workspace) do
+    [
+      "cd #{shell_escape(workspace)}",
+      "exec #{Config.claude_command()}"
+    ]
+    |> Enum.join(" && ")
+  end
+
+  defp port_metadata(port, worker_host) when is_port(port) do
+    base_metadata =
+      case :erlang.port_info(port, :os_pid) do
+        {:os_pid, os_pid} ->
+          %{claude_app_server_pid: to_string(os_pid)}
+
+        _ ->
+          %{}
+      end
+
+    case worker_host do
+      host when is_binary(host) -> Map.put(base_metadata, :worker_host, host)
+      _ -> base_metadata
+    end
+  end
+
+  defp send_initialize(port) do
+    payload = %{
+      "method" => "initialize",
+      "id" => @initialize_id,
+      "params" => %{
+        "capabilities" => %{
+          "experimentalApi" => true
+        },
+        "clientInfo" => %{
+          "name" => "symphony-orchestrator",
+          "title" => "Symphony Orchestrator",
+          "version" => "0.1.0"
+        }
+      }
+    }
+
+    send_message(port, payload)
+
+    with {:ok, _} <- await_response(port, @initialize_id) do
+      send_message(port, %{"method" => "initialized", "params" => %{}})
+      :ok
+    end
+  end
+
+  defp session_settings(workspace, nil) do
+    Config.claude_runtime_settings(workspace)
+  end
+
+  defp session_settings(workspace, worker_host) when is_binary(worker_host) do
+    Config.claude_runtime_settings(workspace, remote: true)
+  end
+
+  defp do_start_session(port, workspace, session_settings) do
+    case send_initialize(port) do
+      :ok -> start_thread(port, workspace, session_settings)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp start_thread(port, workspace, %{permission_mode: permission_mode}) do
+    send_message(port, %{
+      "method" => "thread/start",
+      "id" => @thread_start_id,
+      "params" => %{
+        "cwd" => workspace,
+        "permissionMode" => permission_mode
+      }
+    })
+
+    case await_response(port, @thread_start_id) do
+      {:ok, %{"thread" => thread_payload}} ->
+        case thread_payload do
+          %{"id" => thread_id} -> {:ok, thread_id}
+          _ -> {:error, {:invalid_thread_payload, thread_payload}}
+        end
+
+      other ->
+        other
+    end
+  end
+
+  defp start_turn(port, thread_id, prompt, issue, workspace) do
+    send_message(port, %{
+      "method" => "turn/start",
+      "id" => @turn_start_id,
+      "params" => %{
+        "threadId" => thread_id,
+        "input" => [
+          %{
+            "type" => "text",
+            "text" => prompt
+          }
+        ],
+        "cwd" => workspace,
+        "title" => "#{issue.identifier}: #{issue.title}"
+      }
+    })
+
+    case await_response(port, @turn_start_id) do
+      {:ok, %{"turn" => %{"id" => turn_id}}} -> {:ok, turn_id}
+      other -> other
+    end
+  end
+
+  defp await_turn_completion(port, on_message, tool_executor, auto_approve_requests, timeout_ms) do
+    receive_loop(
+      port,
+      on_message,
+      timeout_ms,
+      "",
+      tool_executor,
+      auto_approve_requests
+    )
+  end
+
+  defp receive_loop(port, on_message, timeout_ms, pending_line, tool_executor, auto_approve_requests) do
+    receive do
+      {^port, {:data, {:eol, chunk}}} ->
+        complete_line = pending_line <> to_string(chunk)
+        handle_incoming(port, on_message, complete_line, timeout_ms, tool_executor, auto_approve_requests)
+
+      {^port, {:data, {:noeol, chunk}}} ->
+        receive_loop(
+          port,
+          on_message,
+          timeout_ms,
+          pending_line <> to_string(chunk),
+          tool_executor,
+          auto_approve_requests
+        )
+
+      {^port, {:exit_status, status}} ->
+        {:error, {:port_exit, status}}
+    after
+      timeout_ms ->
+        {:error, :turn_timeout}
+    end
+  end
+
+  defp handle_incoming(port, on_message, data, timeout_ms, tool_executor, auto_approve_requests) do
+    payload_string = to_string(data)
+
+    case Jason.decode(payload_string) do
+      {:ok, %{"method" => "turn/completed"} = payload} ->
+        emit_turn_event(on_message, :turn_completed, payload, payload_string, port, payload)
+        {:ok, :turn_completed}
+
+      {:ok, %{"method" => "turn/failed", "params" => _} = payload} ->
+        emit_turn_event(
+          on_message,
+          :turn_failed,
+          payload,
+          payload_string,
+          port,
+          Map.get(payload, "params")
+        )
+
+        {:error, {:turn_failed, Map.get(payload, "params")}}
+
+      {:ok, %{"method" => "turn/cancelled", "params" => _} = payload} ->
+        emit_turn_event(
+          on_message,
+          :turn_cancelled,
+          payload,
+          payload_string,
+          port,
+          Map.get(payload, "params")
+        )
+
+        {:error, {:turn_cancelled, Map.get(payload, "params")}}
+
+      {:ok, %{"method" => method} = payload}
+      when is_binary(method) ->
+        handle_turn_method(
+          port,
+          on_message,
+          payload,
+          payload_string,
+          method,
+          timeout_ms,
+          tool_executor,
+          auto_approve_requests
+        )
+
+      {:ok, payload} ->
+        emit_message(
+          on_message,
+          :other_message,
+          %{
+            payload: payload,
+            raw: payload_string
+          },
+          metadata_from_message(port, payload)
+        )
+
+        receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests)
+
+      {:error, _reason} ->
+        log_non_json_stream_line(payload_string, "turn stream")
+
+        if protocol_message_candidate?(payload_string) do
+          emit_message(
+            on_message,
+            :malformed,
+            %{
+              payload: payload_string,
+              raw: payload_string
+            },
+            metadata_from_message(port, %{raw: payload_string})
+          )
+        end
+
+        receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests)
+    end
+  end
+
+  defp emit_turn_event(on_message, event, payload, payload_string, port, payload_details) do
+    emit_message(
+      on_message,
+      event,
+      %{
+        payload: payload,
+        raw: payload_string,
+        details: payload_details
+      },
+      metadata_from_message(port, payload)
+    )
+  end
+
+  defp handle_turn_method(
+         port,
+         on_message,
+         payload,
+         payload_string,
+         method,
+         timeout_ms,
+         tool_executor,
+         auto_approve_requests
+       ) do
+    metadata = metadata_from_message(port, payload)
+
+    case maybe_handle_approval_request(
+           port,
+           method,
+           payload,
+           payload_string,
+           on_message,
+           metadata,
+           tool_executor,
+           auto_approve_requests
+         ) do
+      :input_required ->
+        emit_message(
+          on_message,
+          :turn_input_required,
+          %{payload: payload, raw: payload_string},
+          metadata
+        )
+
+        {:error, {:turn_input_required, payload}}
+
+      :approved ->
+        receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests)
+
+      :approval_required ->
+        emit_message(
+          on_message,
+          :approval_required,
+          %{payload: payload, raw: payload_string},
+          metadata
+        )
+
+        {:error, {:approval_required, payload}}
+
+      :unhandled ->
+        if needs_input?(method, payload) do
+          emit_message(
+            on_message,
+            :turn_input_required,
+            %{payload: payload, raw: payload_string},
+            metadata
+          )
+
+          {:error, {:turn_input_required, payload}}
+        else
+          emit_message(
+            on_message,
+            :notification,
+            %{
+              payload: payload,
+              raw: payload_string
+            },
+            metadata
+          )
+
+          Logger.debug("Claude notification: #{inspect(method)}")
+          receive_loop(port, on_message, timeout_ms, "", tool_executor, auto_approve_requests)
+        end
+    end
+  end
+
+  defp maybe_handle_approval_request(
+         port,
+         "item/commandExecution/requestApproval",
+         %{"id" => id} = payload,
+         payload_string,
+         on_message,
+         metadata,
+         _tool_executor,
+         auto_approve_requests
+       ) do
+    approve_or_require(
+      port,
+      id,
+      "acceptForSession",
+      payload,
+      payload_string,
+      on_message,
+      metadata,
+      auto_approve_requests
+    )
+  end
+
+  defp maybe_handle_approval_request(
+         port,
+         "item/tool/call",
+         %{"id" => id, "params" => params} = payload,
+         payload_string,
+         on_message,
+         metadata,
+         tool_executor,
+         _auto_approve_requests
+       ) do
+    tool_name = tool_call_name(params)
+    arguments = tool_call_arguments(params)
+
+    result =
+      tool_name
+      |> tool_executor.(arguments)
+      |> normalize_dynamic_tool_result()
+
+    send_message(port, %{
+      "id" => id,
+      "result" => result
+    })
+
+    event =
+      case result do
+        %{"success" => true} -> :tool_call_completed
+        _ when is_nil(tool_name) -> :unsupported_tool_call
+        _ -> :tool_call_failed
+      end
+
+    emit_message(on_message, event, %{payload: payload, raw: payload_string}, metadata)
+
+    :approved
+  end
+
+  defp maybe_handle_approval_request(
+         port,
+         "execCommandApproval",
+         %{"id" => id} = payload,
+         payload_string,
+         on_message,
+         metadata,
+         _tool_executor,
+         auto_approve_requests
+       ) do
+    approve_or_require(
+      port,
+      id,
+      "approved_for_session",
+      payload,
+      payload_string,
+      on_message,
+      metadata,
+      auto_approve_requests
+    )
+  end
+
+  defp maybe_handle_approval_request(
+         port,
+         "applyPatchApproval",
+         %{"id" => id} = payload,
+         payload_string,
+         on_message,
+         metadata,
+         _tool_executor,
+         auto_approve_requests
+       ) do
+    approve_or_require(
+      port,
+      id,
+      "approved_for_session",
+      payload,
+      payload_string,
+      on_message,
+      metadata,
+      auto_approve_requests
+    )
+  end
+
+  defp maybe_handle_approval_request(
+         port,
+         "item/fileChange/requestApproval",
+         %{"id" => id} = payload,
+         payload_string,
+         on_message,
+         metadata,
+         _tool_executor,
+         auto_approve_requests
+       ) do
+    approve_or_require(
+      port,
+      id,
+      "acceptForSession",
+      payload,
+      payload_string,
+      on_message,
+      metadata,
+      auto_approve_requests
+    )
+  end
+
+  defp maybe_handle_approval_request(
+         port,
+         "item/tool/requestUserInput",
+         %{"id" => id, "params" => params} = payload,
+         payload_string,
+         on_message,
+         metadata,
+         _tool_executor,
+         auto_approve_requests
+       ) do
+    maybe_auto_answer_tool_request_user_input(
+      port,
+      id,
+      params,
+      payload,
+      payload_string,
+      on_message,
+      metadata,
+      auto_approve_requests
+    )
+  end
+
+  defp maybe_handle_approval_request(
+         _port,
+         _method,
+         _payload,
+         _payload_string,
+         _on_message,
+         _metadata,
+         _tool_executor,
+         _auto_approve_requests
+       ) do
+    :unhandled
+  end
+
+  defp normalize_dynamic_tool_result(%{"success" => success} = result) when is_boolean(success) do
+    output =
+      case Map.get(result, "output") do
+        existing_output when is_binary(existing_output) -> existing_output
+        _ -> dynamic_tool_output(result)
+      end
+
+    content_items =
+      case Map.get(result, "contentItems") do
+        existing_items when is_list(existing_items) -> existing_items
+        _ -> dynamic_tool_content_items(output)
+      end
+
+    result
+    |> Map.put("output", output)
+    |> Map.put("contentItems", content_items)
+  end
+
+  defp normalize_dynamic_tool_result(result) do
+    %{
+      "success" => false,
+      "output" => inspect(result),
+      "contentItems" => dynamic_tool_content_items(inspect(result))
+    }
+  end
+
+  defp dynamic_tool_output(%{"contentItems" => [%{"text" => text} | _]}) when is_binary(text), do: text
+  defp dynamic_tool_output(result), do: Jason.encode!(result, pretty: true)
+
+  defp dynamic_tool_content_items(output) when is_binary(output) do
+    [
+      %{
+        "type" => "inputText",
+        "text" => output
+      }
+    ]
+  end
+
+  defp approve_or_require(
+         port,
+         id,
+         decision,
+         payload,
+         payload_string,
+         on_message,
+         metadata,
+         true
+       ) do
+    send_message(port, %{"id" => id, "result" => %{"decision" => decision}})
+
+    emit_message(
+      on_message,
+      :approval_auto_approved,
+      %{payload: payload, raw: payload_string, decision: decision},
+      metadata
+    )
+
+    :approved
+  end
+
+  defp approve_or_require(
+         _port,
+         _id,
+         _decision,
+         _payload,
+         _payload_string,
+         _on_message,
+         _metadata,
+         false
+       ) do
+    :approval_required
+  end
+
+  defp maybe_auto_answer_tool_request_user_input(
+         port,
+         id,
+         params,
+         payload,
+         payload_string,
+         on_message,
+         metadata,
+         true
+       ) do
+    case tool_request_user_input_approval_answers(params) do
+      {:ok, answers, decision} ->
+        send_message(port, %{"id" => id, "result" => %{"answers" => answers}})
+
+        emit_message(
+          on_message,
+          :approval_auto_approved,
+          %{payload: payload, raw: payload_string, decision: decision},
+          metadata
+        )
+
+        :approved
+
+      :error ->
+        reply_with_non_interactive_tool_input_answer(
+          port,
+          id,
+          params,
+          payload,
+          payload_string,
+          on_message,
+          metadata
+        )
+    end
+  end
+
+  defp maybe_auto_answer_tool_request_user_input(
+         port,
+         id,
+         params,
+         payload,
+         payload_string,
+         on_message,
+         metadata,
+         false
+       ) do
+    reply_with_non_interactive_tool_input_answer(
+      port,
+      id,
+      params,
+      payload,
+      payload_string,
+      on_message,
+      metadata
+    )
+  end
+
+  defp tool_request_user_input_approval_answers(%{"questions" => questions}) when is_list(questions) do
+    answers =
+      Enum.reduce_while(questions, %{}, fn question, acc ->
+        case tool_request_user_input_approval_answer(question) do
+          {:ok, question_id, answer_label} ->
+            {:cont, Map.put(acc, question_id, %{"answers" => [answer_label]})}
+
+          :error ->
+            {:halt, :error}
+        end
+      end)
+
+    case answers do
+      :error -> :error
+      answer_map when map_size(answer_map) > 0 -> {:ok, answer_map, "Approve this Session"}
+      _ -> :error
+    end
+  end
+
+  defp tool_request_user_input_approval_answers(_params), do: :error
+
+  defp reply_with_non_interactive_tool_input_answer(
+         port,
+         id,
+         params,
+         payload,
+         payload_string,
+         on_message,
+         metadata
+       ) do
+    case tool_request_user_input_unavailable_answers(params) do
+      {:ok, answers} ->
+        send_message(port, %{"id" => id, "result" => %{"answers" => answers}})
+
+        emit_message(
+          on_message,
+          :tool_input_auto_answered,
+          %{payload: payload, raw: payload_string, answer: @non_interactive_tool_input_answer},
+          metadata
+        )
+
+        :approved
+
+      :error ->
+        :input_required
+    end
+  end
+
+  defp tool_request_user_input_unavailable_answers(%{"questions" => questions}) when is_list(questions) do
+    answers =
+      Enum.reduce_while(questions, %{}, fn question, acc ->
+        case tool_request_user_input_question_id(question) do
+          {:ok, question_id} ->
+            {:cont, Map.put(acc, question_id, %{"answers" => [@non_interactive_tool_input_answer]})}
+
+          :error ->
+            {:halt, :error}
+        end
+      end)
+
+    case answers do
+      :error -> :error
+      answer_map when map_size(answer_map) > 0 -> {:ok, answer_map}
+      _ -> :error
+    end
+  end
+
+  defp tool_request_user_input_unavailable_answers(_params), do: :error
+
+  defp tool_request_user_input_question_id(%{"id" => question_id}) when is_binary(question_id),
+    do: {:ok, question_id}
+
+  defp tool_request_user_input_question_id(_question), do: :error
+
+  defp tool_request_user_input_approval_answer(%{"id" => question_id, "options" => options})
+       when is_binary(question_id) and is_list(options) do
+    case tool_request_user_input_approval_option_label(options) do
+      nil -> :error
+      answer_label -> {:ok, question_id, answer_label}
+    end
+  end
+
+  defp tool_request_user_input_approval_answer(_question), do: :error
+
+  defp tool_request_user_input_approval_option_label(options) do
+    options
+    |> Enum.map(&tool_request_user_input_option_label/1)
+    |> Enum.reject(&is_nil/1)
+    |> case do
+      labels ->
+        Enum.find(labels, &(&1 == "Approve this Session")) ||
+          Enum.find(labels, &(&1 == "Approve Once")) ||
+          Enum.find(labels, &approval_option_label?/1)
+    end
+  end
+
+  defp tool_request_user_input_option_label(%{"label" => label}) when is_binary(label), do: label
+  defp tool_request_user_input_option_label(_option), do: nil
+
+  defp approval_option_label?(label) when is_binary(label) do
+    normalized_label =
+      label
+      |> String.trim()
+      |> String.downcase()
+
+    String.starts_with?(normalized_label, "approve") or String.starts_with?(normalized_label, "allow")
+  end
+
+  defp await_response(port, request_id) do
+    with_timeout_response(port, request_id, Config.settings!().claude.read_timeout_ms, "")
+  end
+
+  defp with_timeout_response(port, request_id, timeout_ms, pending_line) do
+    receive do
+      {^port, {:data, {:eol, chunk}}} ->
+        complete_line = pending_line <> to_string(chunk)
+        handle_response(port, request_id, complete_line, timeout_ms)
+
+      {^port, {:data, {:noeol, chunk}}} ->
+        with_timeout_response(port, request_id, timeout_ms, pending_line <> to_string(chunk))
+
+      {^port, {:exit_status, status}} ->
+        {:error, {:port_exit, status}}
+    after
+      timeout_ms ->
+        {:error, :response_timeout}
+    end
+  end
+
+  defp handle_response(port, request_id, data, timeout_ms) do
+    payload = to_string(data)
+
+    case Jason.decode(payload) do
+      {:ok, %{"id" => ^request_id, "error" => error}} ->
+        {:error, {:response_error, error}}
+
+      {:ok, %{"id" => ^request_id, "result" => result}} ->
+        {:ok, result}
+
+      {:ok, %{"id" => ^request_id} = response_payload} ->
+        {:error, {:response_error, response_payload}}
+
+      {:ok, %{} = other} ->
+        Logger.debug("Ignoring message while waiting for response: #{inspect(other)}")
+        with_timeout_response(port, request_id, timeout_ms, "")
+
+      {:error, _} ->
+        log_non_json_stream_line(payload, "response stream")
+        with_timeout_response(port, request_id, timeout_ms, "")
+    end
+  end
+
+  defp log_non_json_stream_line(data, stream_label) do
+    text =
+      data
+      |> to_string()
+      |> String.trim()
+      |> String.slice(0, @max_stream_log_bytes)
+
+    if text != "" do
+      if String.match?(text, ~r/\b(error|warn|warning|failed|fatal|panic|exception)\b/i) do
+        Logger.warning("Claude #{stream_label} output: #{text}")
+      else
+        Logger.debug("Claude #{stream_label} output: #{text}")
+      end
+    end
+  end
+
+  defp protocol_message_candidate?(data) do
+    data
+    |> to_string()
+    |> String.trim_leading()
+    |> String.starts_with?("{")
+  end
+
+  defp issue_context(%{id: issue_id, identifier: identifier}) do
+    "issue_id=#{issue_id} issue_identifier=#{identifier}"
+  end
+
+  defp stop_port(port) when is_port(port) do
+    case :erlang.port_info(port) do
+      :undefined ->
+        :ok
+
+      _ ->
+        try do
+          Port.close(port)
+          :ok
+        rescue
+          ArgumentError ->
+            :ok
+        end
+    end
+  end
+
+  defp emit_message(on_message, event, details, metadata) when is_function(on_message, 1) do
+    message = metadata |> Map.merge(details) |> Map.put(:event, event) |> Map.put(:timestamp, DateTime.utc_now())
+    on_message.(message)
+  end
+
+  defp metadata_from_message(port, payload) do
+    port |> port_metadata(nil) |> maybe_set_usage(payload)
+  end
+
+  defp maybe_set_usage(metadata, payload) when is_map(payload) do
+    usage = Map.get(payload, "usage") || Map.get(payload, :usage)
+
+    if is_map(usage) do
+      Map.put(metadata, :usage, usage)
+    else
+      metadata
+    end
+  end
+
+  defp maybe_set_usage(metadata, _payload), do: metadata
+
+  defp shell_escape(value) when is_binary(value) do
+    "'" <> String.replace(value, "'", "'\"'\"'") <> "'"
+  end
+
+  defp default_on_message(_message), do: :ok
+
+  defp tool_call_name(params) when is_map(params) do
+    case Map.get(params, "tool") || Map.get(params, :tool) || Map.get(params, "name") || Map.get(params, :name) do
+      name when is_binary(name) ->
+        case String.trim(name) do
+          "" -> nil
+          trimmed -> trimmed
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp tool_call_name(_params), do: nil
+
+  defp tool_call_arguments(params) when is_map(params) do
+    Map.get(params, "arguments") || Map.get(params, :arguments) || %{}
+  end
+
+  defp tool_call_arguments(_params), do: %{}
+
+  defp send_message(port, message) do
+    line =
+      message
+      |> Map.put_new("jsonrpc", "2.0")
+      |> Jason.encode!()
+      |> Kernel.<>("\n")
+
+    Port.command(port, line)
+  end
+
+  defp needs_input?(method, payload)
+       when is_binary(method) and is_map(payload) do
+    String.starts_with?(method, "turn/") && input_required_method?(method, payload)
+  end
+
+  defp needs_input?(_method, _payload), do: false
+
+  defp input_required_method?(method, payload) when is_binary(method) do
+    method in [
+      "turn/input_required",
+      "turn/needs_input",
+      "turn/need_input",
+      "turn/request_input",
+      "turn/request_response",
+      "turn/provide_input",
+      "turn/approval_required"
+    ] || request_payload_requires_input?(payload)
+  end
+
+  defp request_payload_requires_input?(payload) do
+    params = Map.get(payload, "params")
+    needs_input_field?(payload) || needs_input_field?(params)
+  end
+
+  defp needs_input_field?(payload) when is_map(payload) do
+    Map.get(payload, "requiresInput") == true or
+      Map.get(payload, "needsInput") == true or
+      Map.get(payload, "input_required") == true or
+      Map.get(payload, "inputRequired") == true or
+      Map.get(payload, "type") == "input_required" or
+      Map.get(payload, "type") == "needs_input"
+  end
+
+  defp needs_input_field?(_payload), do: false
+end

--- a/elixir/lib/symphony_elixir/claude/dynamic_tool.ex
+++ b/elixir/lib/symphony_elixir/claude/dynamic_tool.ex
@@ -1,0 +1,209 @@
+defmodule SymphonyElixir.Claude.DynamicTool do
+  @moduledoc """
+  Executes client-side tool calls requested by Claude app-server turns.
+  """
+
+  alias SymphonyElixir.Linear.Client
+
+  @linear_graphql_tool "linear_graphql"
+  @linear_graphql_description """
+  Execute a raw GraphQL query or mutation against Linear using Symphony's configured auth.
+  """
+  @linear_graphql_input_schema %{
+    "type" => "object",
+    "additionalProperties" => false,
+    "required" => ["query"],
+    "properties" => %{
+      "query" => %{
+        "type" => "string",
+        "description" => "GraphQL query or mutation document to execute against Linear."
+      },
+      "variables" => %{
+        "type" => ["object", "null"],
+        "description" => "Optional GraphQL variables object.",
+        "additionalProperties" => true
+      }
+    }
+  }
+
+  @spec execute(String.t() | nil, term(), keyword()) :: map()
+  def execute(tool, arguments, opts \\ []) do
+    case tool do
+      @linear_graphql_tool ->
+        execute_linear_graphql(arguments, opts)
+
+      other ->
+        failure_response(%{
+          "error" => %{
+            "message" => "Unsupported dynamic tool: #{inspect(other)}.",
+            "supportedTools" => supported_tool_names()
+          }
+        })
+    end
+  end
+
+  @spec tool_specs() :: [map()]
+  def tool_specs do
+    [
+      %{
+        "name" => @linear_graphql_tool,
+        "description" => @linear_graphql_description,
+        "inputSchema" => @linear_graphql_input_schema
+      }
+    ]
+  end
+
+  defp execute_linear_graphql(arguments, opts) do
+    linear_client = Keyword.get(opts, :linear_client, &Client.graphql/3)
+
+    with {:ok, query, variables} <- normalize_linear_graphql_arguments(arguments),
+         {:ok, response} <- linear_client.(query, variables, []) do
+      graphql_response(response)
+    else
+      {:error, reason} ->
+        failure_response(tool_error_payload(reason))
+    end
+  end
+
+  defp normalize_linear_graphql_arguments(arguments) when is_binary(arguments) do
+    case String.trim(arguments) do
+      "" -> {:error, :missing_query}
+      query -> {:ok, query, %{}}
+    end
+  end
+
+  defp normalize_linear_graphql_arguments(arguments) when is_map(arguments) do
+    case normalize_query(arguments) do
+      {:ok, query} ->
+        case normalize_variables(arguments) do
+          {:ok, variables} ->
+            {:ok, query, variables}
+
+          {:error, reason} ->
+            {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp normalize_linear_graphql_arguments(_arguments), do: {:error, :invalid_arguments}
+
+  defp normalize_query(arguments) do
+    case Map.get(arguments, "query") || Map.get(arguments, :query) do
+      query when is_binary(query) ->
+        case String.trim(query) do
+          "" -> {:error, :missing_query}
+          trimmed -> {:ok, trimmed}
+        end
+
+      _ ->
+        {:error, :missing_query}
+    end
+  end
+
+  defp normalize_variables(arguments) do
+    case Map.get(arguments, "variables") || Map.get(arguments, :variables) || %{} do
+      variables when is_map(variables) -> {:ok, variables}
+      _ -> {:error, :invalid_variables}
+    end
+  end
+
+  defp graphql_response(response) do
+    success =
+      case response do
+        %{"errors" => errors} when is_list(errors) and errors != [] -> false
+        %{errors: errors} when is_list(errors) and errors != [] -> false
+        _ -> true
+      end
+
+    dynamic_tool_response(success, encode_payload(response))
+  end
+
+  defp failure_response(payload) do
+    dynamic_tool_response(false, encode_payload(payload))
+  end
+
+  defp dynamic_tool_response(success, output) when is_boolean(success) and is_binary(output) do
+    %{
+      "success" => success,
+      "output" => output,
+      "contentItems" => [
+        %{
+          "type" => "inputText",
+          "text" => output
+        }
+      ]
+    }
+  end
+
+  defp encode_payload(payload) when is_map(payload) or is_list(payload) do
+    Jason.encode!(payload, pretty: true)
+  end
+
+  defp encode_payload(payload), do: inspect(payload)
+
+  defp tool_error_payload(:missing_query) do
+    %{
+      "error" => %{
+        "message" => "`linear_graphql` requires a non-empty `query` string."
+      }
+    }
+  end
+
+  defp tool_error_payload(:invalid_arguments) do
+    %{
+      "error" => %{
+        "message" => "`linear_graphql` expects either a GraphQL query string or an object with `query` and optional `variables`."
+      }
+    }
+  end
+
+  defp tool_error_payload(:invalid_variables) do
+    %{
+      "error" => %{
+        "message" => "`linear_graphql.variables` must be a JSON object when provided."
+      }
+    }
+  end
+
+  defp tool_error_payload(:missing_linear_api_token) do
+    %{
+      "error" => %{
+        "message" => "Symphony is missing Linear auth. Set `linear.api_key` in `WORKFLOW.md` or export `LINEAR_API_KEY`."
+      }
+    }
+  end
+
+  defp tool_error_payload({:linear_api_status, status}) do
+    %{
+      "error" => %{
+        "message" => "Linear GraphQL request failed with HTTP #{status}.",
+        "status" => status
+      }
+    }
+  end
+
+  defp tool_error_payload({:linear_api_request, reason}) do
+    %{
+      "error" => %{
+        "message" => "Linear GraphQL request failed before receiving a successful response.",
+        "reason" => inspect(reason)
+      }
+    }
+  end
+
+  defp tool_error_payload(reason) do
+    %{
+      "error" => %{
+        "message" => "Linear GraphQL tool execution failed.",
+        "reason" => inspect(reason)
+      }
+    }
+  end
+
+  defp supported_tool_names do
+    Enum.map(tool_specs(), & &1["name"])
+  end
+end

--- a/elixir/lib/symphony_elixir/config.ex
+++ b/elixir/lib/symphony_elixir/config.ex
@@ -20,6 +20,14 @@ defmodule SymphonyElixir.Config do
   {% endif %}
   """
 
+  @type claude_runtime_settings :: %{
+          command: String.t(),
+          permission_mode: String.t(),
+          turn_timeout_ms: pos_integer(),
+          read_timeout_ms: pos_integer(),
+          stall_timeout_ms: non_neg_integer()
+        }
+
   @spec settings() :: {:ok, Schema.t()} | {:error, term()}
   def settings do
     case Workflow.current() do
@@ -80,6 +88,52 @@ defmodule SymphonyElixir.Config do
       validate_semantics(settings)
     end
   end
+
+  @spec claude_runtime_settings(Path.t() | nil, keyword()) ::
+          {:ok, claude_runtime_settings()} | {:error, term()}
+  def claude_runtime_settings(_workspace \\ nil, _opts \\ []) do
+    with {:ok, settings} <- settings() do
+      {:ok,
+       %{
+         command: claude_command(settings),
+         permission_mode: settings.claude.permission_mode,
+         turn_timeout_ms: settings.claude.turn_timeout_ms,
+         read_timeout_ms: settings.claude.read_timeout_ms,
+         stall_timeout_ms: settings.claude.stall_timeout_ms
+       }}
+    end
+  end
+
+  @spec agent_runtime_settings(Path.t() | nil, keyword()) ::
+          {:ok, claude_runtime_settings()} | {:error, term()}
+  def agent_runtime_settings(workspace \\ nil, opts \\ []) do
+    claude_runtime_settings(workspace, opts)
+  end
+
+  @spec claude_command() :: String.t()
+  def claude_command do
+    settings!() |> claude_command()
+  end
+
+  @spec claude_command(Schema.t()) :: String.t()
+  def claude_command(%Schema{} = settings) do
+    case settings.claude.command do
+      command when is_binary(command) -> command
+      _ -> default_claude_command()
+    end
+  end
+
+  @spec agent_command() :: String.t()
+  def agent_command do
+    claude_command()
+  end
+
+  @spec agent_command(Schema.t()) :: String.t()
+  def agent_command(%Schema{} = settings) do
+    claude_command(settings)
+  end
+
+  defp default_claude_command, do: "claude-app-server --listen stdio://"
 
   defp validate_semantics(settings) do
     cond do

--- a/elixir/lib/symphony_elixir/config/schema.ex
+++ b/elixir/lib/symphony_elixir/config/schema.ex
@@ -131,7 +131,6 @@ defmodule SymphonyElixir.Config.Schema do
       field(:max_concurrent_agents, :integer, default: 10)
       field(:max_turns, :integer, default: 20)
       field(:max_retry_backoff_ms, :integer, default: 300_000)
-      field(:stall_timeout_ms, :integer, default: 300_000)
       field(:max_concurrent_agents_by_state, :map, default: %{})
     end
 
@@ -140,15 +139,54 @@ defmodule SymphonyElixir.Config.Schema do
       schema
       |> cast(
         attrs,
-        [:max_concurrent_agents, :max_turns, :max_retry_backoff_ms, :stall_timeout_ms, :max_concurrent_agents_by_state],
+        [
+          :max_concurrent_agents,
+          :max_turns,
+          :max_retry_backoff_ms,
+          :max_concurrent_agents_by_state
+        ],
         empty_values: []
       )
       |> validate_number(:max_concurrent_agents, greater_than: 0)
       |> validate_number(:max_turns, greater_than: 0)
       |> validate_number(:max_retry_backoff_ms, greater_than: 0)
-      |> validate_number(:stall_timeout_ms, greater_than_or_equal_to: 0)
       |> update_change(:max_concurrent_agents_by_state, &Schema.normalize_state_limits/1)
       |> Schema.validate_state_limits(:max_concurrent_agents_by_state)
+    end
+  end
+
+  defmodule Claude do
+    @moduledoc false
+    use Ecto.Schema
+    import Ecto.Changeset
+
+    @primary_key false
+    embedded_schema do
+      field(:command, :string, default: "claude-app-server --listen stdio://")
+      field(:permission_mode, :string, default: "dontAsk")
+      field(:turn_timeout_ms, :integer, default: 3_600_000)
+      field(:read_timeout_ms, :integer, default: 5_000)
+      field(:stall_timeout_ms, :integer, default: 300_000)
+    end
+
+    @spec changeset(%__MODULE__{}, map()) :: Ecto.Changeset.t()
+    def changeset(schema, attrs) do
+      schema
+      |> cast(
+        attrs,
+        [
+          :command,
+          :permission_mode,
+          :turn_timeout_ms,
+          :read_timeout_ms,
+          :stall_timeout_ms
+        ],
+        empty_values: []
+      )
+      |> validate_required([:command, :permission_mode])
+      |> validate_number(:turn_timeout_ms, greater_than: 0)
+      |> validate_number(:read_timeout_ms, greater_than: 0)
+      |> validate_number(:stall_timeout_ms, greater_than_or_equal_to: 0)
     end
   end
 
@@ -220,6 +258,7 @@ defmodule SymphonyElixir.Config.Schema do
     embeds_one(:workspace, Workspace, on_replace: :update, defaults_to_struct: true)
     embeds_one(:worker, Worker, on_replace: :update, defaults_to_struct: true)
     embeds_one(:agent, Agent, on_replace: :update, defaults_to_struct: true)
+    embeds_one(:claude, Claude, on_replace: :update, defaults_to_struct: true)
     embeds_one(:hooks, Hooks, on_replace: :update, defaults_to_struct: true)
     embeds_one(:observability, Observability, on_replace: :update, defaults_to_struct: true)
     embeds_one(:server, Server, on_replace: :update, defaults_to_struct: true)
@@ -283,6 +322,7 @@ defmodule SymphonyElixir.Config.Schema do
     |> cast_embed(:workspace, with: &Workspace.changeset/2)
     |> cast_embed(:worker, with: &Worker.changeset/2)
     |> cast_embed(:agent, with: &Agent.changeset/2)
+    |> cast_embed(:claude, with: &Claude.changeset/2)
     |> cast_embed(:hooks, with: &Hooks.changeset/2)
     |> cast_embed(:observability, with: &Observability.changeset/2)
     |> cast_embed(:server, with: &Server.changeset/2)
@@ -300,7 +340,13 @@ defmodule SymphonyElixir.Config.Schema do
       | root: resolve_path_value(settings.workspace.root, Path.join(System.tmp_dir!(), "symphony_workspaces"))
     }
 
-    %{settings | tracker: tracker, workspace: workspace}
+    claude = %{
+      settings.claude
+      | command: settings.claude.command,
+        permission_mode: settings.claude.permission_mode
+    }
+
+    %{settings | tracker: tracker, workspace: workspace, claude: claude}
   end
 
   defp normalize_keys(value) when is_map(value) do
@@ -311,9 +357,6 @@ defmodule SymphonyElixir.Config.Schema do
 
   defp normalize_keys(value) when is_list(value), do: Enum.map(value, &normalize_keys/1)
   defp normalize_keys(value), do: value
-
-  defp normalize_optional_map(nil), do: nil
-  defp normalize_optional_map(value) when is_map(value), do: normalize_keys(value)
 
   defp normalize_key(value) when is_atom(value), do: Atom.to_string(value)
   defp normalize_key(value), do: to_string(value)
@@ -396,47 +439,12 @@ defmodule SymphonyElixir.Config.Schema do
 
   defp normalize_secret_value(_value), do: nil
 
-  defp default_turn_sandbox_policy(workspace) do
-    %{
-      "type" => "workspaceWrite",
-      "writableRoots" => [workspace],
-      "readOnlyAccess" => %{"type" => "fullAccess"},
-      "networkAccess" => false,
-      "excludeTmpdirEnvVar" => false,
-      "excludeSlashTmp" => false
-    }
-  end
-
-  defp default_runtime_turn_sandbox_policy(workspace_root, opts) when is_binary(workspace_root) do
-    if Keyword.get(opts, :remote, false) do
-      {:ok, default_turn_sandbox_policy(workspace_root)}
-    else
-      with expanded_workspace_root <- expand_local_workspace_root(workspace_root),
-           {:ok, canonical_workspace_root} <- PathSafety.canonicalize(expanded_workspace_root) do
-        {:ok, default_turn_sandbox_policy(canonical_workspace_root)}
-      end
-    end
-  end
-
-  defp default_runtime_turn_sandbox_policy(workspace_root, _opts) do
-    {:error, {:unsafe_turn_sandbox_policy, {:invalid_workspace_root, workspace_root}}}
-  end
-
   defp default_workspace_root(workspace, _fallback) when is_binary(workspace) and workspace != "",
     do: workspace
 
   defp default_workspace_root(nil, fallback), do: fallback
   defp default_workspace_root("", fallback), do: fallback
   defp default_workspace_root(workspace, _fallback), do: workspace
-
-  defp expand_local_workspace_root(workspace_root)
-       when is_binary(workspace_root) and workspace_root != "" do
-    Path.expand(workspace_root)
-  end
-
-  defp expand_local_workspace_root(_workspace_root) do
-    Path.expand(Path.join(System.tmp_dir!(), "symphony_workspaces"))
-  end
 
   defp format_errors(changeset) do
     changeset

--- a/elixir/lib/symphony_elixir/orchestrator.ex
+++ b/elixir/lib/symphony_elixir/orchestrator.ex
@@ -1,6 +1,6 @@
 defmodule SymphonyElixir.Orchestrator do
   @moduledoc """
-  Polls Linear and dispatches repository copies to agent workers.
+  Polls Linear and dispatches repository copies to Claude-backed workers.
   """
 
   use GenServer
@@ -14,7 +14,7 @@ defmodule SymphonyElixir.Orchestrator do
   @failure_retry_base_ms 10_000
   # Slightly above the dashboard render interval so "checking now…" can render.
   @poll_transition_render_delay_ms 20
-  @empty_agent_totals %{
+  @empty_claude_totals %{
     input_tokens: 0,
     output_tokens: 0,
     total_tokens: 0,
@@ -33,12 +33,12 @@ defmodule SymphonyElixir.Orchestrator do
       :poll_check_in_progress,
       :tick_timer_ref,
       :tick_token,
-      :rate_limits,
       running: %{},
       completed: MapSet.new(),
       claimed: MapSet.new(),
       retry_attempts: %{},
-      agent_totals: nil
+      claude_totals: nil,
+      claude_rate_limits: nil
     ]
   end
 
@@ -60,7 +60,8 @@ defmodule SymphonyElixir.Orchestrator do
       poll_check_in_progress: false,
       tick_timer_ref: nil,
       tick_token: nil,
-      agent_totals: @empty_agent_totals
+      claude_totals: @empty_claude_totals,
+      claude_rate_limits: nil
     }
 
     run_terminal_workspace_cleanup()
@@ -178,6 +179,29 @@ defmodule SymphonyElixir.Orchestrator do
         {:noreply, %{state | running: Map.put(running, issue_id, updated_running_entry)}}
     end
   end
+
+  def handle_info(
+        {:claude_worker_update, issue_id, %{event: _, timestamp: _} = update},
+        %{running: running} = state
+      ) do
+    case Map.get(running, issue_id) do
+      nil ->
+        {:noreply, state}
+
+      running_entry ->
+        {updated_running_entry, token_delta} = integrate_claude_update(running_entry, update)
+
+        state =
+          state
+          |> apply_claude_token_delta(token_delta)
+          |> apply_claude_rate_limits(update)
+
+        notify_dashboard()
+        {:noreply, %{state | running: Map.put(running, issue_id, updated_running_entry)}}
+    end
+  end
+
+  def handle_info({:claude_worker_update, _issue_id, _update}, state), do: {:noreply, state}
 
   def handle_info({:retry_issue, issue_id, retry_token}, state) do
     result =
@@ -422,7 +446,7 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp reconcile_stalled_running_issues(%State{} = state) do
-    timeout_ms = Config.settings!().agent.stall_timeout_ms
+    timeout_ms = Config.settings!().claude.stall_timeout_ms
 
     cond do
       timeout_ms <= 0 ->
@@ -455,7 +479,7 @@ defmodule SymphonyElixir.Orchestrator do
       |> terminate_running_issue(issue_id, false)
       |> schedule_issue_retry(issue_id, next_attempt, %{
         identifier: identifier,
-        error: "stalled for #{elapsed_ms}ms without agent activity"
+        error: "stalled for #{elapsed_ms}ms without claude activity"
       })
     else
       state
@@ -475,7 +499,7 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp last_activity_timestamp(running_entry) when is_map(running_entry) do
-    Map.get(running_entry, :last_agent_timestamp) || Map.get(running_entry, :started_at)
+    Map.get(running_entry, :last_claude_timestamp) || Map.get(running_entry, :started_at)
   end
 
   defp last_activity_timestamp(_running_entry), do: nil
@@ -684,16 +708,16 @@ defmodule SymphonyElixir.Orchestrator do
             worker_host: worker_host,
             workspace_path: nil,
             session_id: nil,
-            last_agent_message: nil,
-            last_agent_timestamp: nil,
-            last_agent_event: nil,
-            agent_app_server_pid: nil,
-            agent_input_tokens: 0,
-            agent_output_tokens: 0,
-            agent_total_tokens: 0,
-            agent_last_reported_input_tokens: 0,
-            agent_last_reported_output_tokens: 0,
-            agent_last_reported_total_tokens: 0,
+            last_claude_message: nil,
+            last_claude_timestamp: nil,
+            last_claude_event: nil,
+            claude_app_server_pid: nil,
+            claude_input_tokens: 0,
+            claude_output_tokens: 0,
+            claude_total_tokens: 0,
+            claude_last_reported_input_tokens: 0,
+            claude_last_reported_output_tokens: 0,
+            claude_last_reported_total_tokens: 0,
             turn_count: 0,
             retry_attempt: normalize_retry_attempt(attempt),
             started_at: DateTime.utc_now()
@@ -1089,15 +1113,15 @@ defmodule SymphonyElixir.Orchestrator do
           worker_host: Map.get(metadata, :worker_host),
           workspace_path: Map.get(metadata, :workspace_path),
           session_id: metadata.session_id,
-          agent_app_server_pid: metadata.agent_app_server_pid,
-          agent_input_tokens: metadata.agent_input_tokens,
-          agent_output_tokens: metadata.agent_output_tokens,
-          agent_total_tokens: metadata.agent_total_tokens,
+          claude_app_server_pid: metadata.claude_app_server_pid,
+          claude_input_tokens: metadata.claude_input_tokens,
+          claude_output_tokens: metadata.claude_output_tokens,
+          claude_total_tokens: metadata.claude_total_tokens,
           turn_count: Map.get(metadata, :turn_count, 0),
           started_at: metadata.started_at,
-          last_agent_timestamp: metadata.last_agent_timestamp,
-          last_agent_message: metadata.last_agent_message,
-          last_agent_event: metadata.last_agent_event,
+          last_claude_timestamp: metadata.last_claude_timestamp,
+          last_claude_message: metadata.last_claude_message,
+          last_claude_event: metadata.last_claude_event,
           runtime_seconds: running_seconds(metadata.started_at, now)
         }
       end)
@@ -1120,8 +1144,8 @@ defmodule SymphonyElixir.Orchestrator do
      %{
        running: running,
        retrying: retrying,
-       agent_totals: state.agent_totals,
-       rate_limits: Map.get(state, :rate_limits),
+       claude_totals: state.claude_totals,
+       rate_limits: Map.get(state, :claude_rate_limits),
        polling: %{
          checking?: state.poll_check_in_progress == true,
          next_poll_in_ms: next_poll_in_ms(state.next_poll_due_at_ms, now_ms),
@@ -1145,48 +1169,48 @@ defmodule SymphonyElixir.Orchestrator do
      }, state}
   end
 
-  defp integrate_agent_update(running_entry, %{event: event, timestamp: timestamp} = update) do
+  defp integrate_claude_update(running_entry, %{event: event, timestamp: timestamp} = update) do
     token_delta = extract_token_delta(running_entry, update)
-    agent_input_tokens = Map.get(running_entry, :agent_input_tokens, 0)
-    agent_output_tokens = Map.get(running_entry, :agent_output_tokens, 0)
-    agent_total_tokens = Map.get(running_entry, :agent_total_tokens, 0)
-    agent_app_server_pid = Map.get(running_entry, :agent_app_server_pid)
-    last_reported_input = Map.get(running_entry, :agent_last_reported_input_tokens, 0)
-    last_reported_output = Map.get(running_entry, :agent_last_reported_output_tokens, 0)
-    last_reported_total = Map.get(running_entry, :agent_last_reported_total_tokens, 0)
+    claude_input_tokens = Map.get(running_entry, :claude_input_tokens, 0)
+    claude_output_tokens = Map.get(running_entry, :claude_output_tokens, 0)
+    claude_total_tokens = Map.get(running_entry, :claude_total_tokens, 0)
+    claude_app_server_pid = Map.get(running_entry, :claude_app_server_pid)
+    last_reported_input = Map.get(running_entry, :claude_last_reported_input_tokens, 0)
+    last_reported_output = Map.get(running_entry, :claude_last_reported_output_tokens, 0)
+    last_reported_total = Map.get(running_entry, :claude_last_reported_total_tokens, 0)
     turn_count = Map.get(running_entry, :turn_count, 0)
 
     {
       Map.merge(running_entry, %{
-        last_agent_timestamp: timestamp,
-        last_agent_message: summarize_agent_update(update),
+        last_claude_timestamp: timestamp,
+        last_claude_message: summarize_claude_update(update),
         session_id: session_id_for_update(running_entry.session_id, update),
-        last_agent_event: event,
-        agent_app_server_pid: agent_app_server_pid_for_update(agent_app_server_pid, update),
-        agent_input_tokens: agent_input_tokens + token_delta.input_tokens,
-        agent_output_tokens: agent_output_tokens + token_delta.output_tokens,
-        agent_total_tokens: agent_total_tokens + token_delta.total_tokens,
-        agent_last_reported_input_tokens: max(last_reported_input, token_delta.input_reported),
-        agent_last_reported_output_tokens: max(last_reported_output, token_delta.output_reported),
-        agent_last_reported_total_tokens: max(last_reported_total, token_delta.total_reported),
+        last_claude_event: event,
+        claude_app_server_pid: claude_app_server_pid_for_update(claude_app_server_pid, update),
+        claude_input_tokens: claude_input_tokens + token_delta.input_tokens,
+        claude_output_tokens: claude_output_tokens + token_delta.output_tokens,
+        claude_total_tokens: claude_total_tokens + token_delta.total_tokens,
+        claude_last_reported_input_tokens: max(last_reported_input, token_delta.input_reported),
+        claude_last_reported_output_tokens: max(last_reported_output, token_delta.output_reported),
+        claude_last_reported_total_tokens: max(last_reported_total, token_delta.total_reported),
         turn_count: turn_count_for_update(turn_count, running_entry.session_id, update)
       }),
       token_delta
     }
   end
 
-  defp agent_app_server_pid_for_update(_existing, %{agent_app_server_pid: pid})
+  defp claude_app_server_pid_for_update(_existing, %{claude_app_server_pid: pid})
        when is_binary(pid),
        do: pid
 
-  defp agent_app_server_pid_for_update(_existing, %{agent_app_server_pid: pid})
+  defp claude_app_server_pid_for_update(_existing, %{claude_app_server_pid: pid})
        when is_integer(pid),
        do: Integer.to_string(pid)
 
-  defp agent_app_server_pid_for_update(_existing, %{agent_app_server_pid: pid}) when is_list(pid),
+  defp claude_app_server_pid_for_update(_existing, %{claude_app_server_pid: pid}) when is_list(pid),
     do: to_string(pid)
 
-  defp agent_app_server_pid_for_update(existing, _update), do: existing
+  defp claude_app_server_pid_for_update(existing, _update), do: existing
 
   defp session_id_for_update(_existing, %{session_id: session_id}) when is_binary(session_id),
     do: session_id
@@ -1211,7 +1235,7 @@ defmodule SymphonyElixir.Orchestrator do
 
   defp turn_count_for_update(_existing_count, _existing_session_id, _update), do: 0
 
-  defp summarize_agent_update(update) do
+  defp summarize_claude_update(update) do
     %{
       event: update[:event],
       message: update[:payload] || update[:raw],
@@ -1253,9 +1277,9 @@ defmodule SymphonyElixir.Orchestrator do
   defp record_session_completion_totals(state, running_entry) when is_map(running_entry) do
     runtime_seconds = running_seconds(running_entry.started_at, DateTime.utc_now())
 
-    agent_totals =
+    claude_totals =
       apply_token_delta(
-        state.agent_totals,
+        state.claude_totals,
         %{
           input_tokens: 0,
           output_tokens: 0,
@@ -1264,7 +1288,7 @@ defmodule SymphonyElixir.Orchestrator do
         }
       )
 
-    %{state | agent_totals: agent_totals}
+    %{state | claude_totals: claude_totals}
   end
 
   defp record_session_completion_totals(state, _running_entry), do: state
@@ -1288,13 +1312,35 @@ defmodule SymphonyElixir.Orchestrator do
     available_slots(state) > 0 and state_slots_available?(issue, state.running)
   end
 
-  defp apply_token_delta(agent_totals, token_delta) do
-    input_tokens = Map.get(agent_totals, :input_tokens, 0) + token_delta.input_tokens
-    output_tokens = Map.get(agent_totals, :output_tokens, 0) + token_delta.output_tokens
-    total_tokens = Map.get(agent_totals, :total_tokens, 0) + token_delta.total_tokens
+  defp apply_claude_token_delta(
+         %{claude_totals: claude_totals} = state,
+         %{input_tokens: input, output_tokens: output, total_tokens: total} = token_delta
+       )
+       when is_integer(input) and is_integer(output) and is_integer(total) do
+    %{state | claude_totals: apply_token_delta(claude_totals, token_delta)}
+  end
+
+  defp apply_claude_token_delta(state, _token_delta), do: state
+
+  defp apply_claude_rate_limits(%State{} = state, update) when is_map(update) do
+    case extract_rate_limits(update) do
+      %{} = rate_limits ->
+        %{state | claude_rate_limits: rate_limits}
+
+      _ ->
+        state
+    end
+  end
+
+  defp apply_claude_rate_limits(state, _update), do: state
+
+  defp apply_token_delta(claude_totals, token_delta) do
+    input_tokens = Map.get(claude_totals, :input_tokens, 0) + token_delta.input_tokens
+    output_tokens = Map.get(claude_totals, :output_tokens, 0) + token_delta.output_tokens
+    total_tokens = Map.get(claude_totals, :total_tokens, 0) + token_delta.total_tokens
 
     seconds_running =
-      Map.get(agent_totals, :seconds_running, 0) + Map.get(token_delta, :seconds_running, 0)
+      Map.get(claude_totals, :seconds_running, 0) + Map.get(token_delta, :seconds_running, 0)
 
     %{
       input_tokens: max(0, input_tokens),
@@ -1313,19 +1359,19 @@ defmodule SymphonyElixir.Orchestrator do
         running_entry,
         :input,
         usage,
-        :agent_last_reported_input_tokens
+        :claude_last_reported_input_tokens
       ),
       compute_token_delta(
         running_entry,
         :output,
         usage,
-        :agent_last_reported_output_tokens
+        :claude_last_reported_output_tokens
       ),
       compute_token_delta(
         running_entry,
         :total,
         usage,
-        :agent_last_reported_total_tokens
+        :claude_last_reported_total_tokens
       )
     }
     |> Tuple.to_list()
@@ -1369,6 +1415,7 @@ defmodule SymphonyElixir.Orchestrator do
     ]
 
     Enum.find_value(payloads, &absolute_token_usage_from_payload/1) ||
+      Enum.find_value(payloads, &usage_update_from_payload/1) ||
       Enum.find_value(payloads, &turn_completed_usage_from_payload/1) ||
       %{}
   end
@@ -1398,6 +1445,22 @@ defmodule SymphonyElixir.Orchestrator do
   end
 
   defp absolute_token_usage_from_payload(_payload), do: nil
+
+  defp usage_update_from_payload(payload) when is_map(payload) do
+    method = Map.get(payload, "method") || Map.get(payload, :method)
+
+    if method in ["usage/update", :usage_update] do
+      usage =
+        Map.get(payload, "usage") ||
+          Map.get(payload, :usage) ||
+          map_at_path(payload, ["params", "usage"]) ||
+          map_at_path(payload, [:params, :usage])
+
+      if is_map(usage) and integer_token_map?(usage), do: usage
+    end
+  end
+
+  defp usage_update_from_payload(_payload), do: nil
 
   defp turn_completed_usage_from_payload(payload) when is_map(payload) do
     method = Map.get(payload, "method") || Map.get(payload, :method)

--- a/elixir/lib/symphony_elixir/status_dashboard.ex
+++ b/elixir/lib/symphony_elixir/status_dashboard.ex
@@ -307,15 +307,15 @@ defmodule SymphonyElixir.StatusDashboard do
 
   defp snapshot_with_samples(token_samples, now_ms) do
     case snapshot_payload() do
-      {:ok, %{running: running, retrying: retrying, agent_totals: agent_totals} = snapshot} ->
-        total_tokens = Map.get(agent_totals, :total_tokens, 0)
+      {:ok, %{running: running, retrying: retrying, claude_totals: claude_totals} = snapshot} ->
+        total_tokens = Map.get(claude_totals, :total_tokens, 0)
 
         {
           {:ok,
            %{
              running: running,
              retrying: retrying,
-             agent_totals: agent_totals,
+             claude_totals: claude_totals,
              rate_limits: Map.get(snapshot, :rate_limits),
              polling: Map.get(snapshot, :polling)
            }},
@@ -332,14 +332,14 @@ defmodule SymphonyElixir.StatusDashboard do
 
   defp format_snapshot_content(snapshot_data, tps, terminal_columns_override \\ nil) do
     case snapshot_data do
-      {:ok, %{running: running, retrying: retrying, agent_totals: agent_totals} = snapshot} ->
+      {:ok, %{running: running, retrying: retrying, claude_totals: claude_totals} = snapshot} ->
         rate_limits = Map.get(snapshot, :rate_limits)
         project_link_lines = format_project_link_lines()
         project_refresh_line = format_project_refresh_line(Map.get(snapshot, :polling))
-        agent_input_tokens = Map.get(agent_totals, :input_tokens, 0)
-        agent_output_tokens = Map.get(agent_totals, :output_tokens, 0)
-        agent_total_tokens = Map.get(agent_totals, :total_tokens, 0)
-        agent_seconds_running = Map.get(agent_totals, :seconds_running, 0)
+        claude_input_tokens = Map.get(claude_totals, :input_tokens, 0)
+        claude_output_tokens = Map.get(claude_totals, :output_tokens, 0)
+        claude_total_tokens = Map.get(claude_totals, :total_tokens, 0)
+        claude_seconds_running = Map.get(claude_totals, :seconds_running, 0)
         agent_count = length(running)
         max_agents = Config.settings!().agent.max_concurrent_agents
         running_event_width = running_event_width(terminal_columns_override)
@@ -355,13 +355,13 @@ defmodule SymphonyElixir.StatusDashboard do
              colorize("#{max_agents}", @ansi_gray),
            colorize("│ Throughput: ", @ansi_bold) <> colorize("#{format_tps(tps)} tps", @ansi_cyan),
            colorize("│ Runtime: ", @ansi_bold) <>
-             colorize(format_runtime_seconds(agent_seconds_running), @ansi_magenta),
+             colorize(format_runtime_seconds(claude_seconds_running), @ansi_magenta),
            colorize("│ Tokens: ", @ansi_bold) <>
-             colorize("in #{format_count(agent_input_tokens)}", @ansi_yellow) <>
+             colorize("in #{format_count(claude_input_tokens)}", @ansi_yellow) <>
              colorize(" | ", @ansi_gray) <>
-             colorize("out #{format_count(agent_output_tokens)}", @ansi_yellow) <>
+             colorize("out #{format_count(claude_output_tokens)}", @ansi_yellow) <>
              colorize(" | ", @ansi_gray) <>
-             colorize("total #{format_count(agent_total_tokens)}", @ansi_yellow),
+             colorize("total #{format_count(claude_total_tokens)}", @ansi_yellow),
            colorize("│ Rate Limits: ", @ansi_bold) <> format_rate_limits(rate_limits),
            project_link_lines,
            project_refresh_line,
@@ -553,14 +553,14 @@ defmodule SymphonyElixir.StatusDashboard do
         %{
           running: running,
           retrying: retrying,
-          agent_totals: agent_totals
+          claude_totals: claude_totals
         } = snapshot
         when is_list(running) and is_list(retrying) ->
           {:ok,
            %{
              running: running,
              retrying: retrying,
-             agent_totals: agent_totals,
+             claude_totals: claude_totals,
              rate_limits: Map.get(snapshot, :rate_limits),
              polling: Map.get(snapshot, :polling)
            }}
@@ -592,21 +592,21 @@ defmodule SymphonyElixir.StatusDashboard do
     state = running_entry.state || "unknown"
     state_display = format_cell(to_string(state), @running_stage_width)
     session = running_entry.session_id |> compact_session_id() |> format_cell(@running_session_width)
-    pid = format_cell(running_entry.agent_app_server_pid || "n/a", @running_pid_width)
-    total_tokens = running_entry.agent_total_tokens || 0
+    pid = format_cell(running_entry.claude_app_server_pid || "n/a", @running_pid_width)
+    total_tokens = running_entry.claude_total_tokens || 0
     runtime_seconds = running_entry.runtime_seconds || 0
     turn_count = Map.get(running_entry, :turn_count, 0)
     age = format_cell(format_runtime_and_turns(runtime_seconds, turn_count), @running_age_width)
-    event = running_entry.last_agent_event || "none"
-    event_label = format_cell(summarize_message(running_entry.last_agent_message), running_event_width)
+    event = running_entry.last_claude_event || "none"
+    event_label = format_cell(summarize_message(running_entry.last_claude_message), running_event_width)
 
     tokens = format_count(total_tokens) |> format_cell(@running_tokens_width, :right)
 
     status_color =
       case event do
         :none -> @ansi_red
-        "agent/event/token_count" -> @ansi_yellow
-        "agent/event/task_started" -> @ansi_green
+        "claude/event/token_count" -> @ansi_yellow
+        "claude/event/task_started" -> @ansi_green
         "turn_completed" -> @ansi_magenta
         _ -> @ansi_blue
       end
@@ -1045,8 +1045,8 @@ defmodule SymphonyElixir.StatusDashboard do
     colorize("●", color_code)
   end
 
-  defp snapshot_total_tokens({:ok, %{agent_totals: agent_totals}}) when is_map(agent_totals) do
-    Map.get(agent_totals, :total_tokens, 0)
+  defp snapshot_total_tokens({:ok, %{claude_totals: claude_totals}}) when is_map(claude_totals) do
+    Map.get(claude_totals, :total_tokens, 0)
   end
 
   defp snapshot_total_tokens(_snapshot_data), do: 0
@@ -1068,33 +1068,33 @@ defmodule SymphonyElixir.StatusDashboard do
   end
 
   @doc false
-  @spec humanize_agent_message(term()) :: String.t()
-  def humanize_agent_message(nil), do: "no agent message yet"
+  @spec humanize_claude_message(term()) :: String.t()
+  def humanize_claude_message(nil), do: "no claude message yet"
 
-  def humanize_agent_message(%{event: event, message: message}) do
-    payload = unwrap_agent_message_payload(message)
+  def humanize_claude_message(%{event: event, message: message}) do
+    payload = unwrap_claude_message_payload(message)
 
-    (humanize_agent_event(event, message, payload) || humanize_agent_payload(payload))
+    (humanize_claude_event(event, message, payload) || humanize_claude_payload(payload))
     |> truncate(140)
   end
 
-  def humanize_agent_message(%{message: message}) do
+  def humanize_claude_message(%{message: message}) do
     message
-    |> unwrap_agent_message_payload()
-    |> humanize_agent_payload()
+    |> unwrap_claude_message_payload()
+    |> humanize_claude_payload()
     |> truncate(140)
   end
 
-  def humanize_agent_message(message) do
+  def humanize_claude_message(message) do
     message
-    |> unwrap_agent_message_payload()
-    |> humanize_agent_payload()
+    |> unwrap_claude_message_payload()
+    |> humanize_claude_payload()
     |> truncate(140)
   end
 
-  defp summarize_message(message), do: humanize_agent_message(message)
+  defp summarize_message(message), do: humanize_claude_message(message)
 
-  defp humanize_agent_event(:session_started, _message, payload) do
+  defp humanize_claude_event(:session_started, _message, payload) do
     session_id = map_value(payload, ["session_id", :session_id])
 
     if is_binary(session_id) do
@@ -1104,9 +1104,9 @@ defmodule SymphonyElixir.StatusDashboard do
     end
   end
 
-  defp humanize_agent_event(:turn_input_required, _message, _payload), do: "turn blocked: waiting for user input"
+  defp humanize_claude_event(:turn_input_required, _message, _payload), do: "turn blocked: waiting for user input"
 
-  defp humanize_agent_event(:approval_auto_approved, message, payload) do
+  defp humanize_claude_event(:approval_auto_approved, message, payload) do
     method =
       map_value(payload, ["method", :method]) ||
         map_path(message, ["payload", "method"]) ||
@@ -1116,7 +1116,7 @@ defmodule SymphonyElixir.StatusDashboard do
 
     base =
       if is_binary(method) do
-        "#{humanize_agent_method(method, payload)} (auto-approved)"
+        "#{humanize_claude_method(method, payload)} (auto-approved)"
       else
         "approval request auto-approved"
       end
@@ -1124,11 +1124,11 @@ defmodule SymphonyElixir.StatusDashboard do
     if is_binary(decision), do: "#{base}: #{decision}", else: base
   end
 
-  defp humanize_agent_event(:tool_input_auto_answered, message, payload) do
+  defp humanize_claude_event(:tool_input_auto_answered, message, payload) do
     answer = map_value(message, ["answer", :answer])
 
     base =
-      case humanize_agent_method("item/tool/requestUserInput", payload) do
+      case humanize_claude_method("item/tool/requestUserInput", payload) do
         nil -> "tool input auto-answered"
         text -> "#{text} (auto-answered)"
       end
@@ -1136,23 +1136,23 @@ defmodule SymphonyElixir.StatusDashboard do
     if is_binary(answer), do: "#{base}: #{inline_text(answer)}", else: base
   end
 
-  defp humanize_agent_event(:tool_call_completed, _message, payload),
+  defp humanize_claude_event(:tool_call_completed, _message, payload),
     do: humanize_dynamic_tool_event("dynamic tool call completed", payload)
 
-  defp humanize_agent_event(:tool_call_failed, _message, payload),
+  defp humanize_claude_event(:tool_call_failed, _message, payload),
     do: humanize_dynamic_tool_event("dynamic tool call failed", payload)
 
-  defp humanize_agent_event(:unsupported_tool_call, _message, payload),
+  defp humanize_claude_event(:unsupported_tool_call, _message, payload),
     do: humanize_dynamic_tool_event("unsupported dynamic tool call rejected", payload)
 
-  defp humanize_agent_event(:turn_ended_with_error, message, _payload), do: "turn ended with error: #{format_reason(message)}"
-  defp humanize_agent_event(:startup_failed, message, _payload), do: "startup failed: #{format_reason(message)}"
-  defp humanize_agent_event(:turn_failed, _message, payload), do: humanize_agent_method("turn/failed", payload)
-  defp humanize_agent_event(:turn_cancelled, _message, _payload), do: "turn cancelled"
-  defp humanize_agent_event(:malformed, _message, _payload), do: "malformed JSON event from agent"
-  defp humanize_agent_event(_event, _message, _payload), do: nil
+  defp humanize_claude_event(:turn_ended_with_error, message, _payload), do: "turn ended with error: #{format_reason(message)}"
+  defp humanize_claude_event(:startup_failed, message, _payload), do: "startup failed: #{format_reason(message)}"
+  defp humanize_claude_event(:turn_failed, _message, payload), do: humanize_claude_method("turn/failed", payload)
+  defp humanize_claude_event(:turn_cancelled, _message, _payload), do: "turn cancelled"
+  defp humanize_claude_event(:malformed, _message, _payload), do: "malformed JSON event from claude"
+  defp humanize_claude_event(_event, _message, _payload), do: nil
 
-  defp unwrap_agent_message_payload(%{} = message) do
+  defp unwrap_claude_message_payload(%{} = message) do
     cond do
       is_binary(map_value(message, ["method", :method])) -> message
       is_binary(map_value(message, ["session_id", :session_id])) -> message
@@ -1161,12 +1161,12 @@ defmodule SymphonyElixir.StatusDashboard do
     end
   end
 
-  defp unwrap_agent_message_payload(message), do: message
+  defp unwrap_claude_message_payload(message), do: message
 
-  defp humanize_agent_payload(%{} = payload) do
+  defp humanize_claude_payload(%{} = payload) do
     case map_value(payload, ["method", :method]) do
       method when is_binary(method) ->
-        humanize_agent_method(method, payload)
+        humanize_claude_method(method, payload)
 
       _ ->
         cond do
@@ -1186,14 +1186,14 @@ defmodule SymphonyElixir.StatusDashboard do
     end
   end
 
-  defp humanize_agent_payload(payload) when is_binary(payload) do
+  defp humanize_claude_payload(payload) when is_binary(payload) do
     payload
     |> String.replace("\n", " ")
     |> sanitize_ansi_and_control_bytes()
     |> String.trim()
   end
 
-  defp humanize_agent_payload(payload) do
+  defp humanize_claude_payload(payload) do
     payload
     |> inspect(pretty: true, limit: 20)
     |> String.replace("\n", " ")
@@ -1208,7 +1208,7 @@ defmodule SymphonyElixir.StatusDashboard do
     |> String.replace(~r/[\x00-\x1F\x7F]/, "")
   end
 
-  defp humanize_agent_method("thread/started", payload) do
+  defp humanize_claude_method("thread/started", payload) do
     thread_id = map_path(payload, ["params", "thread", "id"]) || map_path(payload, [:params, :thread, :id])
 
     if is_binary(thread_id) do
@@ -1218,7 +1218,7 @@ defmodule SymphonyElixir.StatusDashboard do
     end
   end
 
-  defp humanize_agent_method("turn/started", payload) do
+  defp humanize_claude_method("turn/started", payload) do
     turn_id = map_path(payload, ["params", "turn", "id"]) || map_path(payload, [:params, :turn, :id])
 
     if is_binary(turn_id) do
@@ -1228,7 +1228,7 @@ defmodule SymphonyElixir.StatusDashboard do
     end
   end
 
-  defp humanize_agent_method("turn/completed", payload) do
+  defp humanize_claude_method("turn/completed", payload) do
     status =
       map_path(payload, ["params", "turn", "status"]) ||
         map_path(payload, [:params, :turn, :status]) ||
@@ -1250,7 +1250,7 @@ defmodule SymphonyElixir.StatusDashboard do
     "turn completed (#{status})#{usage_suffix}"
   end
 
-  defp humanize_agent_method("turn/failed", payload) do
+  defp humanize_claude_method("turn/failed", payload) do
     error_message =
       map_path(payload, ["params", "error", "message"]) ||
         map_path(payload, [:params, :error, :message])
@@ -1258,9 +1258,9 @@ defmodule SymphonyElixir.StatusDashboard do
     if is_binary(error_message), do: "turn failed: #{error_message}", else: "turn failed"
   end
 
-  defp humanize_agent_method("turn/cancelled", _payload), do: "turn cancelled"
+  defp humanize_claude_method("turn/cancelled", _payload), do: "turn cancelled"
 
-  defp humanize_agent_method("turn/diff/updated", payload) do
+  defp humanize_claude_method("turn/diff/updated", payload) do
     diff =
       map_path(payload, ["params", "diff"]) ||
         map_path(payload, [:params, :diff]) ||
@@ -1274,7 +1274,7 @@ defmodule SymphonyElixir.StatusDashboard do
     end
   end
 
-  defp humanize_agent_method("turn/plan/updated", payload) do
+  defp humanize_claude_method("turn/plan/updated", payload) do
     plan_entries =
       map_path(payload, ["params", "plan"]) ||
         map_path(payload, [:params, :plan]) ||
@@ -1291,7 +1291,7 @@ defmodule SymphonyElixir.StatusDashboard do
     end
   end
 
-  defp humanize_agent_method("thread/tokenUsage/updated", payload) do
+  defp humanize_claude_method("thread/tokenUsage/updated", payload) do
     usage =
       map_path(payload, ["params", "tokenUsage", "total"]) ||
         map_path(payload, [:params, :tokenUsage, :total]) ||
@@ -1303,31 +1303,31 @@ defmodule SymphonyElixir.StatusDashboard do
     end
   end
 
-  defp humanize_agent_method("item/started", payload), do: humanize_item_lifecycle("started", payload)
-  defp humanize_agent_method("item/completed", payload), do: humanize_item_lifecycle("completed", payload)
+  defp humanize_claude_method("item/started", payload), do: humanize_item_lifecycle("started", payload)
+  defp humanize_claude_method("item/completed", payload), do: humanize_item_lifecycle("completed", payload)
 
-  defp humanize_agent_method("item/agentMessage/delta", payload),
+  defp humanize_claude_method("item/agentMessage/delta", payload),
     do: humanize_streaming_event("agent message streaming", payload)
 
-  defp humanize_agent_method("item/plan/delta", payload),
+  defp humanize_claude_method("item/plan/delta", payload),
     do: humanize_streaming_event("plan streaming", payload)
 
-  defp humanize_agent_method("item/reasoning/summaryTextDelta", payload),
+  defp humanize_claude_method("item/reasoning/summaryTextDelta", payload),
     do: humanize_streaming_event("reasoning summary streaming", payload)
 
-  defp humanize_agent_method("item/reasoning/summaryPartAdded", payload),
+  defp humanize_claude_method("item/reasoning/summaryPartAdded", payload),
     do: humanize_streaming_event("reasoning summary section added", payload)
 
-  defp humanize_agent_method("item/reasoning/textDelta", payload),
+  defp humanize_claude_method("item/reasoning/textDelta", payload),
     do: humanize_streaming_event("reasoning text streaming", payload)
 
-  defp humanize_agent_method("item/commandExecution/outputDelta", payload),
+  defp humanize_claude_method("item/commandExecution/outputDelta", payload),
     do: humanize_streaming_event("command output streaming", payload)
 
-  defp humanize_agent_method("item/fileChange/outputDelta", payload),
+  defp humanize_claude_method("item/fileChange/outputDelta", payload),
     do: humanize_streaming_event("file change output streaming", payload)
 
-  defp humanize_agent_method("item/commandExecution/requestApproval", payload) do
+  defp humanize_claude_method("item/commandExecution/requestApproval", payload) do
     command = extract_command(payload)
 
     if is_binary(command) do
@@ -1337,7 +1337,7 @@ defmodule SymphonyElixir.StatusDashboard do
     end
   end
 
-  defp humanize_agent_method("item/fileChange/requestApproval", payload) do
+  defp humanize_claude_method("item/fileChange/requestApproval", payload) do
     change_count = map_path(payload, ["params", "fileChangeCount"]) || map_path(payload, ["params", "changeCount"])
 
     if is_integer(change_count) and change_count > 0 do
@@ -1347,7 +1347,7 @@ defmodule SymphonyElixir.StatusDashboard do
     end
   end
 
-  defp humanize_agent_method("item/tool/requestUserInput", payload) do
+  defp humanize_claude_method("item/tool/requestUserInput", payload) do
     question =
       map_path(payload, ["params", "question"]) ||
         map_path(payload, ["params", "prompt"]) ||
@@ -1361,10 +1361,10 @@ defmodule SymphonyElixir.StatusDashboard do
     end
   end
 
-  defp humanize_agent_method("tool/requestUserInput", payload),
-    do: humanize_agent_method("item/tool/requestUserInput", payload)
+  defp humanize_claude_method("tool/requestUserInput", payload),
+    do: humanize_claude_method("item/tool/requestUserInput", payload)
 
-  defp humanize_agent_method("account/updated", payload) do
+  defp humanize_claude_method("account/updated", payload) do
     auth_mode =
       map_path(payload, ["params", "authMode"]) ||
         map_path(payload, [:params, :authMode]) ||
@@ -1373,7 +1373,7 @@ defmodule SymphonyElixir.StatusDashboard do
     "account updated (auth #{auth_mode})"
   end
 
-  defp humanize_agent_method("account/rateLimits/updated", payload) do
+  defp humanize_claude_method("account/rateLimits/updated", payload) do
     rate_limits =
       map_path(payload, ["params", "rateLimits"]) ||
         map_path(payload, [:params, :rateLimits])
@@ -1381,9 +1381,9 @@ defmodule SymphonyElixir.StatusDashboard do
     "rate limits updated: #{format_rate_limits_summary(rate_limits)}"
   end
 
-  defp humanize_agent_method("account/chatgptAuthTokens/refresh", _payload), do: "account auth token refresh requested"
+  defp humanize_claude_method("account/chatgptAuthTokens/refresh", _payload), do: "account auth token refresh requested"
 
-  defp humanize_agent_method("item/tool/call", payload) do
+  defp humanize_claude_method("item/tool/call", payload) do
     tool = dynamic_tool_name(payload)
 
     if is_binary(tool) and String.trim(tool) != "" do
@@ -1393,11 +1393,11 @@ defmodule SymphonyElixir.StatusDashboard do
     end
   end
 
-  defp humanize_agent_method(<<"agent/event/", suffix::binary>>, payload) do
-    humanize_agent_wrapper_event(suffix, payload)
+  defp humanize_claude_method(<<"claude/event/", suffix::binary>>, payload) do
+    humanize_claude_wrapper_event(suffix, payload)
   end
 
-  defp humanize_agent_method(method, payload) do
+  defp humanize_claude_method(method, payload) do
     msg_type =
       map_path(payload, ["params", "msg", "type"]) ||
         map_path(payload, [:params, :msg, :type])
@@ -1451,7 +1451,7 @@ defmodule SymphonyElixir.StatusDashboard do
     "item #{state}: #{item_type}#{detail_suffix}"
   end
 
-  defp humanize_agent_wrapper_event("mcp_startup_update", payload) do
+  defp humanize_claude_wrapper_event("mcp_startup_update", payload) do
     server =
       map_path(payload, ["params", "msg", "server"]) ||
         map_path(payload, [:params, :msg, :server]) ||
@@ -1465,48 +1465,48 @@ defmodule SymphonyElixir.StatusDashboard do
     "mcp startup: #{server} #{state}"
   end
 
-  defp humanize_agent_wrapper_event("mcp_startup_complete", _payload), do: "mcp startup complete"
-  defp humanize_agent_wrapper_event("task_started", _payload), do: "task started"
-  defp humanize_agent_wrapper_event("user_message", _payload), do: "user message received"
+  defp humanize_claude_wrapper_event("mcp_startup_complete", _payload), do: "mcp startup complete"
+  defp humanize_claude_wrapper_event("task_started", _payload), do: "task started"
+  defp humanize_claude_wrapper_event("user_message", _payload), do: "user message received"
 
-  defp humanize_agent_wrapper_event("item_started", payload) do
+  defp humanize_claude_wrapper_event("item_started", payload) do
     case wrapper_payload_type(payload) do
-      "token_count" -> humanize_agent_wrapper_event("token_count", payload)
+      "token_count" -> humanize_claude_wrapper_event("token_count", payload)
       type when is_binary(type) -> "item started (#{humanize_item_type(type)})"
       _ -> "item started"
     end
   end
 
-  defp humanize_agent_wrapper_event("item_completed", payload) do
+  defp humanize_claude_wrapper_event("item_completed", payload) do
     case wrapper_payload_type(payload) do
-      "token_count" -> humanize_agent_wrapper_event("token_count", payload)
+      "token_count" -> humanize_claude_wrapper_event("token_count", payload)
       type when is_binary(type) -> "item completed (#{humanize_item_type(type)})"
       _ -> "item completed"
     end
   end
 
-  defp humanize_agent_wrapper_event("agent_message_delta", payload),
+  defp humanize_claude_wrapper_event("agent_message_delta", payload),
     do: humanize_streaming_event("agent message streaming", payload)
 
-  defp humanize_agent_wrapper_event("agent_message_content_delta", payload),
+  defp humanize_claude_wrapper_event("agent_message_content_delta", payload),
     do: humanize_streaming_event("agent message content streaming", payload)
 
-  defp humanize_agent_wrapper_event("agent_reasoning_delta", payload),
+  defp humanize_claude_wrapper_event("agent_reasoning_delta", payload),
     do: humanize_streaming_event("reasoning streaming", payload)
 
-  defp humanize_agent_wrapper_event("reasoning_content_delta", payload),
+  defp humanize_claude_wrapper_event("reasoning_content_delta", payload),
     do: humanize_streaming_event("reasoning content streaming", payload)
 
-  defp humanize_agent_wrapper_event("agent_reasoning_section_break", _payload), do: "reasoning section break"
-  defp humanize_agent_wrapper_event("agent_reasoning", payload), do: humanize_reasoning_update(payload)
-  defp humanize_agent_wrapper_event("turn_diff", _payload), do: "turn diff updated"
-  defp humanize_agent_wrapper_event("exec_command_begin", payload), do: humanize_exec_command_begin(payload)
-  defp humanize_agent_wrapper_event("exec_command_end", payload), do: humanize_exec_command_end(payload)
-  defp humanize_agent_wrapper_event("exec_command_output_delta", _payload), do: "command output streaming"
-  defp humanize_agent_wrapper_event("mcp_tool_call_begin", _payload), do: "mcp tool call started"
-  defp humanize_agent_wrapper_event("mcp_tool_call_end", _payload), do: "mcp tool call completed"
+  defp humanize_claude_wrapper_event("agent_reasoning_section_break", _payload), do: "reasoning section break"
+  defp humanize_claude_wrapper_event("agent_reasoning", payload), do: humanize_reasoning_update(payload)
+  defp humanize_claude_wrapper_event("turn_diff", _payload), do: "turn diff updated"
+  defp humanize_claude_wrapper_event("exec_command_begin", payload), do: humanize_exec_command_begin(payload)
+  defp humanize_claude_wrapper_event("exec_command_end", payload), do: humanize_exec_command_end(payload)
+  defp humanize_claude_wrapper_event("exec_command_output_delta", _payload), do: "command output streaming"
+  defp humanize_claude_wrapper_event("mcp_tool_call_begin", _payload), do: "mcp tool call started"
+  defp humanize_claude_wrapper_event("mcp_tool_call_end", _payload), do: "mcp tool call completed"
 
-  defp humanize_agent_wrapper_event("token_count", payload) do
+  defp humanize_claude_wrapper_event("token_count", payload) do
     usage = extract_first_path(payload, token_usage_paths())
 
     case format_usage_counts(usage) do
@@ -1515,7 +1515,7 @@ defmodule SymphonyElixir.StatusDashboard do
     end
   end
 
-  defp humanize_agent_wrapper_event(other, payload) do
+  defp humanize_claude_wrapper_event(other, payload) do
     msg_type =
       map_path(payload, ["params", "msg", "type"]) ||
         map_path(payload, [:params, :msg, :type])

--- a/elixir/lib/symphony_elixir/workspace.ex
+++ b/elixir/lib/symphony_elixir/workspace.ex
@@ -1,6 +1,6 @@
 defmodule SymphonyElixir.Workspace do
   @moduledoc """
-  Creates isolated per-issue workspaces for parallel agents.
+  Creates isolated per-issue workspaces for parallel Claude agents.
   """
 
   require Logger

--- a/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
+++ b/elixir/lib/symphony_elixir_web/live/dashboard_live.ex
@@ -93,16 +93,16 @@ defmodule SymphonyElixirWeb.DashboardLive do
 
           <article class="metric-card">
             <p class="metric-label">Total tokens</p>
-            <p class="metric-value numeric"><%= format_int(@payload.agent_totals.total_tokens) %></p>
+            <p class="metric-value numeric"><%= format_int(@payload.claude_totals.total_tokens) %></p>
             <p class="metric-detail numeric">
-              In <%= format_int(@payload.agent_totals.input_tokens) %> / Out <%= format_int(@payload.agent_totals.output_tokens) %>
+              In <%= format_int(@payload.claude_totals.input_tokens) %> / Out <%= format_int(@payload.claude_totals.output_tokens) %>
             </p>
           </article>
 
           <article class="metric-card">
             <p class="metric-label">Runtime</p>
             <p class="metric-value numeric"><%= format_runtime_seconds(total_runtime_seconds(@payload, @now)) %></p>
-            <p class="metric-detail">Total agent runtime across completed and active sessions.</p>
+            <p class="metric-detail">Total Claude runtime across completed and active sessions.</p>
           </article>
         </section>
 
@@ -144,7 +144,7 @@ defmodule SymphonyElixirWeb.DashboardLive do
                     <th>State</th>
                     <th>Session</th>
                     <th>Runtime / turns</th>
-                    <th>Agent update</th>
+                    <th>Claude update</th>
                     <th>Tokens</th>
                   </tr>
                 </thead>
@@ -262,7 +262,7 @@ defmodule SymphonyElixirWeb.DashboardLive do
   end
 
   defp completed_runtime_seconds(payload) do
-    payload.agent_totals.seconds_running || 0
+    payload.claude_totals.seconds_running || 0
   end
 
   defp total_runtime_seconds(payload, now) do

--- a/elixir/lib/symphony_elixir_web/presenter.ex
+++ b/elixir/lib/symphony_elixir_web/presenter.ex
@@ -19,7 +19,7 @@ defmodule SymphonyElixirWeb.Presenter do
           },
           running: Enum.map(snapshot.running, &running_entry_payload/1),
           retrying: Enum.map(snapshot.retrying, &retry_entry_payload/1),
-          agent_totals: snapshot.agent_totals,
+          claude_totals: snapshot.claude_totals,
           rate_limits: snapshot.rate_limits
         }
 
@@ -76,7 +76,7 @@ defmodule SymphonyElixirWeb.Presenter do
       running: running && running_issue_payload(running),
       retry: retry && retry_issue_payload(retry),
       logs: %{
-        agent_session_logs: []
+        claude_session_logs: []
       },
       recent_events: (running && recent_events_payload(running)) || [],
       last_error: retry && retry.error,
@@ -104,14 +104,14 @@ defmodule SymphonyElixirWeb.Presenter do
       workspace_path: Map.get(entry, :workspace_path),
       session_id: entry.session_id,
       turn_count: Map.get(entry, :turn_count, 0),
-      last_event: entry.last_agent_event,
-      last_message: summarize_message(entry.last_agent_message),
+      last_event: entry.last_claude_event,
+      last_message: summarize_message(entry.last_claude_message),
       started_at: iso8601(entry.started_at),
-      last_event_at: iso8601(entry.last_agent_timestamp),
+      last_event_at: iso8601(entry.last_claude_timestamp),
       tokens: %{
-        input_tokens: entry.agent_input_tokens,
-        output_tokens: entry.agent_output_tokens,
-        total_tokens: entry.agent_total_tokens
+        input_tokens: entry.claude_input_tokens,
+        output_tokens: entry.claude_output_tokens,
+        total_tokens: entry.claude_total_tokens
       }
     }
   end
@@ -136,13 +136,13 @@ defmodule SymphonyElixirWeb.Presenter do
       turn_count: Map.get(running, :turn_count, 0),
       state: running.state,
       started_at: iso8601(running.started_at),
-      last_event: running.last_agent_event,
-      last_message: summarize_message(running.last_agent_message),
-      last_event_at: iso8601(running.last_agent_timestamp),
+      last_event: running.last_claude_event,
+      last_message: summarize_message(running.last_claude_message),
+      last_event_at: iso8601(running.last_claude_timestamp),
       tokens: %{
-        input_tokens: running.agent_input_tokens,
-        output_tokens: running.agent_output_tokens,
-        total_tokens: running.agent_total_tokens
+        input_tokens: running.claude_input_tokens,
+        output_tokens: running.claude_output_tokens,
+        total_tokens: running.claude_total_tokens
       }
     }
   end
@@ -170,16 +170,16 @@ defmodule SymphonyElixirWeb.Presenter do
   defp recent_events_payload(running) do
     [
       %{
-        at: iso8601(running.last_agent_timestamp),
-        event: running.last_agent_event,
-        message: summarize_message(running.last_agent_message)
+        at: iso8601(running.last_claude_timestamp),
+        event: running.last_claude_event,
+        message: summarize_message(running.last_claude_message)
       }
     ]
     |> Enum.reject(&is_nil(&1.at))
   end
 
   defp summarize_message(nil), do: nil
-  defp summarize_message(message), do: StatusDashboard.humanize_agent_message(message)
+  defp summarize_message(message), do: StatusDashboard.humanize_claude_message(message)
 
   defp due_at_iso8601(due_in_ms) when is_integer(due_in_ms) do
     DateTime.utc_now()

--- a/elixir/mix.exs
+++ b/elixir/mix.exs
@@ -20,6 +20,8 @@ defmodule SymphonyElixir.MixProject do
           SymphonyElixir.Orchestrator.State,
           SymphonyElixir.AgentRunner,
           SymphonyElixir.CLI,
+          SymphonyElixir.Claude.AppServer,
+          SymphonyElixir.Claude.DynamicTool,
           SymphonyElixir.HttpServer,
           SymphonyElixir.StatusDashboard,
           SymphonyElixir.LogFile,

--- a/elixir/test/support/live_e2e_docker/Dockerfile
+++ b/elixir/test/support/live_e2e_docker/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ripgrep \
   && rm -rf /var/lib/apt/lists/*
 
-RUN install -d -m 700 /root/.ssh /root/.codex /run/symphony/ssh /var/run/sshd
+RUN install -d -m 700 /root/.ssh /root/.claude /run/symphony/ssh /var/run/sshd
 
-RUN npm install --global @openai/codex
+RUN npm install --global logitropic/claude-app-server @anthropic-ai/claude-code
 
 COPY symphony-live-worker.conf /etc/ssh/sshd_config.d/symphony-live-worker.conf
 COPY live_worker_entrypoint.sh /usr/local/bin/symphony-live-worker

--- a/elixir/test/support/live_e2e_docker/docker-compose.yml
+++ b/elixir/test/support/live_e2e_docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "${SYMPHONY_LIVE_DOCKER_WORKER_1_PORT}:22"
     volumes:
       - ${SYMPHONY_LIVE_DOCKER_AUTHORIZED_KEY}:/run/symphony/ssh/authorized_key.pub:ro
-      - ${SYMPHONY_LIVE_DOCKER_AUTH_JSON}:/root/.codex/auth.json:ro
+      - ${SYMPHONY_LIVE_DOCKER_AUTH_JSON}:/root/.claude/settings.json:ro
 
   worker2:
     build:
@@ -17,4 +17,4 @@ services:
       - "${SYMPHONY_LIVE_DOCKER_WORKER_2_PORT}:22"
     volumes:
       - ${SYMPHONY_LIVE_DOCKER_AUTHORIZED_KEY}:/run/symphony/ssh/authorized_key.pub:ro
-      - ${SYMPHONY_LIVE_DOCKER_AUTH_JSON}:/root/.codex/auth.json:ro
+      - ${SYMPHONY_LIVE_DOCKER_AUTH_JSON}:/root/.claude/settings.json:ro

--- a/elixir/test/support/live_e2e_docker/live_worker_entrypoint.sh
+++ b/elixir/test/support/live_e2e_docker/live_worker_entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-install -d -m 700 /root/.ssh /root/.codex
+install -d -m 700 /root/.ssh /root/.claude
 
 if [ ! -s /run/symphony/ssh/authorized_key.pub ]; then
   echo "missing authorized key at /run/symphony/ssh/authorized_key.pub" >&2

--- a/elixir/test/support/test_support.exs
+++ b/elixir/test/support/test_support.exs
@@ -8,7 +8,7 @@ defmodule SymphonyElixir.TestSupport do
 
       alias SymphonyElixir.AgentRunner
       alias SymphonyElixir.CLI
-      alias SymphonyElixir.Codex.AppServer
+      alias SymphonyElixir.Claude.AppServer
       alias SymphonyElixir.Config
       alias SymphonyElixir.HttpServer
       alias SymphonyElixir.Linear.Client
@@ -107,10 +107,8 @@ defmodule SymphonyElixir.TestSupport do
           max_turns: 20,
           max_retry_backoff_ms: 300_000,
           max_concurrent_agents_by_state: %{},
-          claude_command: "codex app-server",
-          claude_approval_policy: %{reject: %{sandbox_approval: true, rules: true, mcp_elicitations: true}},
-          claude_thread_sandbox: "workspace-write",
-          claude_turn_sandbox_policy: nil,
+          claude_command: "claude-app-server --listen stdio://",
+          claude_permission_mode: "dontAsk",
           claude_turn_timeout_ms: 3_600_000,
           claude_read_timeout_ms: 5_000,
           claude_stall_timeout_ms: 300_000,
@@ -145,9 +143,7 @@ defmodule SymphonyElixir.TestSupport do
     max_retry_backoff_ms = Keyword.get(config, :max_retry_backoff_ms)
     max_concurrent_agents_by_state = Keyword.get(config, :max_concurrent_agents_by_state)
     claude_command = Keyword.get(config, :claude_command)
-    claude_approval_policy = Keyword.get(config, :claude_approval_policy)
-    claude_thread_sandbox = Keyword.get(config, :claude_thread_sandbox)
-    claude_turn_sandbox_policy = Keyword.get(config, :claude_turn_sandbox_policy)
+    claude_permission_mode = Keyword.get(config, :claude_permission_mode)
     claude_turn_timeout_ms = Keyword.get(config, :claude_turn_timeout_ms)
     claude_read_timeout_ms = Keyword.get(config, :claude_read_timeout_ms)
     claude_stall_timeout_ms = Keyword.get(config, :claude_stall_timeout_ms)
@@ -186,9 +182,7 @@ defmodule SymphonyElixir.TestSupport do
         "  max_concurrent_agents_by_state: #{yaml_value(max_concurrent_agents_by_state)}",
         "claude:",
         "  command: #{yaml_value(claude_command)}",
-        "  approval_policy: #{yaml_value(claude_approval_policy)}",
-        "  thread_sandbox: #{yaml_value(claude_thread_sandbox)}",
-        "  turn_sandbox_policy: #{yaml_value(claude_turn_sandbox_policy)}",
+        "  permission_mode: #{yaml_value(claude_permission_mode)}",
         "  turn_timeout_ms: #{yaml_value(claude_turn_timeout_ms)}",
         "  read_timeout_ms: #{yaml_value(claude_read_timeout_ms)}",
         "  stall_timeout_ms: #{yaml_value(claude_stall_timeout_ms)}",

--- a/elixir/test/symphony_elixir/app_server_test.exs
+++ b/elixir/test/symphony_elixir/app_server_test.exs
@@ -76,35 +76,37 @@ defmodule SymphonyElixir.AppServerTest do
     end
   end
 
-  test "app server passes explicit turn sandbox policies through unchanged" do
+  test "app server launches Claude sessions with Claude-compatible startup payloads" do
     test_root =
       Path.join(
         System.tmp_dir!(),
-        "symphony-elixir-app-server-supported-turn-policies-#{System.unique_integer([:positive])}"
+        "symphony-elixir-app-server-claude-provider-#{System.unique_integer([:positive])}"
       )
+
+    previous_path = System.get_env("PATH")
+    previous_trace = System.get_env("SYMP_TEST_CLAUDE_TRACE")
+
+    on_exit(fn ->
+      restore_env("PATH", previous_path)
+      restore_env("SYMP_TEST_CLAUDE_TRACE", previous_trace)
+    end)
 
     try do
       workspace_root = Path.join(test_root, "workspaces")
-      workspace = Path.join(workspace_root, "MT-1001")
-      codex_binary = Path.join(test_root, "fake-codex")
-      trace_file = Path.join(test_root, "codex-supported-turn-policies.trace")
-      previous_trace = System.get_env("SYMP_TEST_CODEx_TRACE")
+      workspace = Path.join(workspace_root, "MT-CLAUDE")
+      claude_binary = Path.join(test_root, "claude-app-server")
+      trace_file = Path.join(test_root, "claude-provider.trace")
 
-      on_exit(fn ->
-        if is_binary(previous_trace) do
-          System.put_env("SYMP_TEST_CODEx_TRACE", previous_trace)
-        else
-          System.delete_env("SYMP_TEST_CODEx_TRACE")
-        end
-      end)
-
-      System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
       File.mkdir_p!(workspace)
+      assert {:ok, canonical_workspace} = SymphonyElixir.PathSafety.canonicalize(workspace)
+      System.put_env("PATH", test_root <> ":" <> (previous_path || ""))
+      System.put_env("SYMP_TEST_CLAUDE_TRACE", trace_file)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-supported-turn-policies.trace}"
+      trace_file="${SYMP_TEST_CLAUDE_TRACE:-/tmp/claude-provider.trace}"
       count=0
+      printf 'ARGV:%s\\n' "$*" >> "$trace_file"
 
       while IFS= read -r line; do
         count=$((count + 1))
@@ -115,13 +117,14 @@ defmodule SymphonyElixir.AppServerTest do
             printf '%s\\n' '{"id":1,"result":{}}'
             ;;
           2)
-            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-1001"}}}'
             ;;
           3)
-            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-1001"}}}'
+            printf '%s\\n' '{"id":2,"result":{"thread":{"id":"thread-claude"}}}'
             ;;
           4)
-            printf '%s\\n' '{"method":"turn/completed"}'
+            printf '%s\\n' '{"id":3,"result":{"turn":{"id":"turn-claude"}}}'
+            printf '%s\\n' '{"method":"usage/update","params":{"thread_id":"thread-claude","turn_id":"turn-claude","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}'
+            printf '%s\\n' '{"method":"turn/completed","params":{"status":"completed","usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}}}'
             exit 0
             ;;
           *)
@@ -131,53 +134,100 @@ defmodule SymphonyElixir.AppServerTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
+
+      write_workflow_file!(Workflow.workflow_file_path(), workspace_root: workspace_root)
 
       issue = %Issue{
-        id: "issue-supported-turn-policies",
-        identifier: "MT-1001",
-        title: "Validate explicit turn sandbox policy passthrough",
-        description: "Ensure runtime startup forwards configured turn sandbox policies unchanged",
+        id: "issue-claude-provider",
+        identifier: "MT-CLAUDE",
+        title: "Run Claude provider",
+        description: "Validate Claude app-server integration",
         state: "In Progress",
-        url: "https://example.org/issues/MT-1001",
+        url: "https://example.org/issues/MT-CLAUDE",
         labels: ["backend"]
       }
 
-      policy_cases = [
-        %{"type" => "dangerFullAccess"},
-        %{"type" => "externalSandbox", "profile" => "remote-ci"},
-        %{"type" => "workspaceWrite", "writableRoots" => ["relative/path"], "networkAccess" => true},
-        %{"type" => "futureSandbox", "nested" => %{"flag" => true}}
-      ]
+      on_message = fn message -> send(self(), {:app_server_message, message}) end
 
-      Enum.each(policy_cases, fn configured_policy ->
-        File.rm(trace_file)
+      run_result =
+        try do
+          AppServer.run(workspace, "Use Claude from Symphony", issue, on_message: on_message)
+        after
+          restore_env("PATH", previous_path)
+        end
 
-        write_workflow_file!(Workflow.workflow_file_path(),
-          workspace_root: workspace_root,
-          codex_command: "#{codex_binary} app-server",
-          codex_turn_sandbox_policy: configured_policy
-        )
+      assert {:ok, _result} = run_result
 
-        assert {:ok, _result} = AppServer.run(workspace, "Validate supported turn policy", issue)
+      trace = File.read!(trace_file)
+      lines = String.split(trace, "\n", trim: true)
 
-        trace = File.read!(trace_file)
-        lines = String.split(trace, "\n", trim: true)
+      assert argv_line = Enum.find(lines, &String.starts_with?(&1, "ARGV:"))
+      assert argv_line =~ "--listen stdio://"
 
-        assert Enum.any?(lines, fn line ->
-                 if String.starts_with?(line, "JSON:") do
-                   line
-                   |> String.trim_leading("JSON:")
-                   |> Jason.decode!()
-                   |> then(fn payload ->
-                     payload["method"] == "turn/start" &&
-                       get_in(payload, ["params", "sandboxPolicy"]) == configured_policy
-                   end)
-                 else
-                   false
-                 end
-               end)
-      end)
+      json_messages =
+        lines
+        |> Enum.filter(&String.starts_with?(&1, "JSON:"))
+        |> Enum.map(fn line ->
+          line
+          |> String.trim_leading("JSON:")
+          |> Jason.decode!()
+        end)
+
+      assert thread_start =
+               Enum.find(json_messages, &(&1["method"] == "thread/start"))
+
+      assert get_in(thread_start, ["params", "cwd"]) == canonical_workspace
+      assert get_in(thread_start, ["params", "permissionMode"]) == "dontAsk"
+      refute Map.has_key?(thread_start["params"], "approvalPolicy")
+      refute Map.has_key?(thread_start["params"], "sandbox")
+      refute Map.has_key?(thread_start["params"], "dynamicTools")
+
+      assert turn_start =
+               Enum.find(json_messages, &(&1["method"] == "turn/start"))
+
+      assert get_in(turn_start, ["params", "threadId"]) == "thread-claude"
+      assert get_in(turn_start, ["params", "cwd"]) == canonical_workspace
+      assert get_in(turn_start, ["params", "title"]) == "MT-CLAUDE: Run Claude provider"
+
+      assert get_in(turn_start, ["params", "input"]) == [
+               %{"type" => "text", "text" => "Use Claude from Symphony"}
+             ]
+
+      refute Map.has_key?(turn_start["params"], "approvalPolicy")
+      refute Map.has_key?(turn_start["params"], "sandboxPolicy")
+
+      assert_received {:app_server_message,
+                       %{event: :session_started}}
+
+      assert_received {:app_server_message,
+                       %{
+                         event: :notification,
+                         payload: %{
+                           "method" => "usage/update",
+                           "params" => %{
+                             "usage" => %{
+                               "input_tokens" => 1,
+                               "output_tokens" => 2,
+                               "total_tokens" => 3
+                             }
+                           }
+                         }
+                       }}
+
+      assert_received {:app_server_message,
+                       %{
+                         event: :turn_completed,
+                         details: %{
+                           "params" => %{
+                             "usage" => %{
+                               "input_tokens" => 1,
+                               "output_tokens" => 2,
+                               "total_tokens" => 3
+                             }
+                           }
+                         }
+                       }}
     after
       File.rm_rf(test_root)
     end
@@ -193,24 +243,24 @@ defmodule SymphonyElixir.AppServerTest do
     try do
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-88")
-      codex_binary = Path.join(test_root, "fake-codex")
-      trace_file = Path.join(test_root, "codex-input.trace")
-      previous_trace = System.get_env("SYMP_TEST_CODEx_TRACE")
+      claude_binary = Path.join(test_root, "fake-claude")
+      trace_file = Path.join(test_root, "claude-input.trace")
+      previous_trace = System.get_env("SYMP_TEST_CLAUDE_TRACE")
 
       on_exit(fn ->
         if is_binary(previous_trace) do
-          System.put_env("SYMP_TEST_CODEx_TRACE", previous_trace)
+          System.put_env("SYMP_TEST_CLAUDE_TRACE", previous_trace)
         else
-          System.delete_env("SYMP_TEST_CODEx_TRACE")
+          System.delete_env("SYMP_TEST_CLAUDE_TRACE")
         end
       end)
 
-      System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
+      System.put_env("SYMP_TEST_CLAUDE_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-input.trace}"
+      trace_file="${SYMP_TEST_CLAUDE_TRACE:-/tmp/claude-input.trace}"
       count=0
       while IFS= read -r line; do
         count=$((count + 1))
@@ -236,18 +286,18 @@ defmodule SymphonyElixir.AppServerTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} app-server"
+        claude_command: "#{claude_binary} app-server"
       )
 
       issue = %Issue{
         id: "issue-input",
         identifier: "MT-88",
         title: "Input needed",
-        description: "Cannot satisfy codex input",
+        description: "Cannot satisfy claude input",
         state: "In Progress",
         url: "https://example.org/issues/MT-88",
         labels: ["backend"]
@@ -272,10 +322,10 @@ defmodule SymphonyElixir.AppServerTest do
     try do
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-89")
-      codex_binary = Path.join(test_root, "fake-codex")
+      claude_binary = Path.join(test_root, "fake-claude")
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
       count=0
       while IFS= read -r _line; do
@@ -299,11 +349,11 @@ defmodule SymphonyElixir.AppServerTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} app-server"
+        claude_command: "#{claude_binary} app-server"
       )
 
       issue = %Issue{
@@ -325,7 +375,7 @@ defmodule SymphonyElixir.AppServerTest do
     end
   end
 
-  test "app server auto-approves command execution approval requests when approval policy is never" do
+  test "app server auto-approves command execution approval requests when Claude permission mode bypasses approvals" do
     test_root =
       Path.join(
         System.tmp_dir!(),
@@ -335,24 +385,24 @@ defmodule SymphonyElixir.AppServerTest do
     try do
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-89")
-      codex_binary = Path.join(test_root, "fake-codex")
-      trace_file = Path.join(test_root, "codex-auto-approve.trace")
-      previous_trace = System.get_env("SYMP_TEST_CODex_TRACE")
+      claude_binary = Path.join(test_root, "fake-claude")
+      trace_file = Path.join(test_root, "claude-auto-approve.trace")
+      previous_trace = System.get_env("SYMP_TEST_CLAUDE_TRACE")
 
       on_exit(fn ->
         if is_binary(previous_trace) do
-          System.put_env("SYMP_TEST_CODex_TRACE", previous_trace)
+          System.put_env("SYMP_TEST_CLAUDE_TRACE", previous_trace)
         else
-          System.delete_env("SYMP_TEST_CODex_TRACE")
+          System.delete_env("SYMP_TEST_CLAUDE_TRACE")
         end
       end)
 
-      System.put_env("SYMP_TEST_CODex_TRACE", trace_file)
+      System.put_env("SYMP_TEST_CLAUDE_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
-      trace_file="${SYMP_TEST_CODex_TRACE:-/tmp/codex-auto-approve.trace}"
+      trace_file="${SYMP_TEST_CLAUDE_TRACE:-/tmp/claude-auto-approve.trace}"
       count=0
       while IFS= read -r line; do
         count=$((count + 1))
@@ -382,12 +432,12 @@ defmodule SymphonyElixir.AppServerTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} app-server",
-        codex_approval_policy: "never"
+        claude_command: "#{claude_binary} app-server",
+        claude_permission_mode: "bypassPermissions"
       )
 
       issue = %Issue{
@@ -401,6 +451,7 @@ defmodule SymphonyElixir.AppServerTest do
       }
 
       assert {:ok, _result} = AppServer.run(workspace, "Handle approval request", issue)
+      assert {:ok, canonical_workspace} = SymphonyElixir.PathSafety.canonicalize(workspace)
 
       trace = File.read!(trace_file)
       lines = String.split(trace, "\n", trim: true)
@@ -427,19 +478,8 @@ defmodule SymphonyElixir.AppServerTest do
                    |> Jason.decode!()
 
                  payload["id"] == 2 and
-                   case get_in(payload, ["params", "dynamicTools"]) do
-                     [
-                       %{
-                         "description" => description,
-                         "inputSchema" => %{"required" => ["query"]},
-                         "name" => "linear_graphql"
-                       }
-                     ] ->
-                       description =~ "Linear"
-
-                     _ ->
-                       false
-                   end
+                   get_in(payload, ["params", "cwd"]) == canonical_workspace and
+                   get_in(payload, ["params", "permissionMode"]) == "bypassPermissions"
                else
                  false
                end
@@ -472,24 +512,24 @@ defmodule SymphonyElixir.AppServerTest do
     try do
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-717")
-      codex_binary = Path.join(test_root, "fake-codex")
-      trace_file = Path.join(test_root, "codex-tool-user-input-auto-approve.trace")
-      previous_trace = System.get_env("SYMP_TEST_CODEx_TRACE")
+      claude_binary = Path.join(test_root, "fake-claude")
+      trace_file = Path.join(test_root, "claude-tool-user-input-auto-approve.trace")
+      previous_trace = System.get_env("SYMP_TEST_CLAUDE_TRACE")
 
       on_exit(fn ->
         if is_binary(previous_trace) do
-          System.put_env("SYMP_TEST_CODEx_TRACE", previous_trace)
+          System.put_env("SYMP_TEST_CLAUDE_TRACE", previous_trace)
         else
-          System.delete_env("SYMP_TEST_CODEx_TRACE")
+          System.delete_env("SYMP_TEST_CLAUDE_TRACE")
         end
       end)
 
-      System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
+      System.put_env("SYMP_TEST_CLAUDE_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-tool-user-input-auto-approve.trace}"
+      trace_file="${SYMP_TEST_CLAUDE_TRACE:-/tmp/claude-tool-user-input-auto-approve.trace}"
       count=0
       while IFS= read -r line; do
         count=$((count + 1))
@@ -519,12 +559,12 @@ defmodule SymphonyElixir.AppServerTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} app-server",
-        codex_approval_policy: "never"
+        claude_command: "#{claude_binary} app-server",
+        claude_permission_mode: "bypassPermissions"
       )
 
       issue = %Issue{
@@ -571,10 +611,10 @@ defmodule SymphonyElixir.AppServerTest do
     try do
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-718")
-      codex_binary = Path.join(test_root, "fake-codex")
+      claude_binary = Path.join(test_root, "fake-claude")
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
       count=0
       while IFS= read -r _line; do
@@ -604,12 +644,12 @@ defmodule SymphonyElixir.AppServerTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} app-server",
-        codex_approval_policy: "never"
+        claude_command: "#{claude_binary} app-server",
+        claude_permission_mode: "bypassPermissions"
       )
 
       issue = %Issue{
@@ -647,24 +687,24 @@ defmodule SymphonyElixir.AppServerTest do
     try do
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-719")
-      codex_binary = Path.join(test_root, "fake-codex")
-      trace_file = Path.join(test_root, "codex-tool-user-input-options.trace")
-      previous_trace = System.get_env("SYMP_TEST_CODEx_TRACE")
+      claude_binary = Path.join(test_root, "fake-claude")
+      trace_file = Path.join(test_root, "claude-tool-user-input-options.trace")
+      previous_trace = System.get_env("SYMP_TEST_CLAUDE_TRACE")
 
       on_exit(fn ->
         if is_binary(previous_trace) do
-          System.put_env("SYMP_TEST_CODEx_TRACE", previous_trace)
+          System.put_env("SYMP_TEST_CLAUDE_TRACE", previous_trace)
         else
-          System.delete_env("SYMP_TEST_CODEx_TRACE")
+          System.delete_env("SYMP_TEST_CLAUDE_TRACE")
         end
       end)
 
-      System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
+      System.put_env("SYMP_TEST_CLAUDE_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-tool-user-input-options.trace}"
+      trace_file="${SYMP_TEST_CLAUDE_TRACE:-/tmp/claude-tool-user-input-options.trace}"
       count=0
       while IFS= read -r line; do
         count=$((count + 1))
@@ -694,11 +734,11 @@ defmodule SymphonyElixir.AppServerTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} app-server"
+        claude_command: "#{claude_binary} app-server"
       )
 
       issue = %Issue{
@@ -747,24 +787,24 @@ defmodule SymphonyElixir.AppServerTest do
     try do
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-90")
-      codex_binary = Path.join(test_root, "fake-codex")
-      trace_file = Path.join(test_root, "codex-tool-call.trace")
-      previous_trace = System.get_env("SYMP_TEST_CODEx_TRACE")
+      claude_binary = Path.join(test_root, "fake-claude")
+      trace_file = Path.join(test_root, "claude-tool-call.trace")
+      previous_trace = System.get_env("SYMP_TEST_CLAUDE_TRACE")
 
       on_exit(fn ->
         if is_binary(previous_trace) do
-          System.put_env("SYMP_TEST_CODEx_TRACE", previous_trace)
+          System.put_env("SYMP_TEST_CLAUDE_TRACE", previous_trace)
         else
-          System.delete_env("SYMP_TEST_CODEx_TRACE")
+          System.delete_env("SYMP_TEST_CLAUDE_TRACE")
         end
       end)
 
-      System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
+      System.put_env("SYMP_TEST_CLAUDE_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-tool-call.trace}"
+      trace_file="${SYMP_TEST_CLAUDE_TRACE:-/tmp/claude-tool-call.trace}"
       count=0
       while IFS= read -r line; do
         count=$((count + 1))
@@ -794,11 +834,11 @@ defmodule SymphonyElixir.AppServerTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} app-server"
+        claude_command: "#{claude_binary} app-server"
       )
 
       issue = %Issue{
@@ -848,24 +888,24 @@ defmodule SymphonyElixir.AppServerTest do
     try do
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-90A")
-      codex_binary = Path.join(test_root, "fake-codex")
-      trace_file = Path.join(test_root, "codex-supported-tool-call.trace")
-      previous_trace = System.get_env("SYMP_TEST_CODEx_TRACE")
+      claude_binary = Path.join(test_root, "fake-claude")
+      trace_file = Path.join(test_root, "claude-supported-tool-call.trace")
+      previous_trace = System.get_env("SYMP_TEST_CLAUDE_TRACE")
 
       on_exit(fn ->
         if is_binary(previous_trace) do
-          System.put_env("SYMP_TEST_CODEx_TRACE", previous_trace)
+          System.put_env("SYMP_TEST_CLAUDE_TRACE", previous_trace)
         else
-          System.delete_env("SYMP_TEST_CODEx_TRACE")
+          System.delete_env("SYMP_TEST_CLAUDE_TRACE")
         end
       end)
 
-      System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
+      System.put_env("SYMP_TEST_CLAUDE_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-supported-tool-call.trace}"
+      trace_file="${SYMP_TEST_CLAUDE_TRACE:-/tmp/claude-supported-tool-call.trace}"
       count=0
       while IFS= read -r line; do
         count=$((count + 1))
@@ -895,11 +935,11 @@ defmodule SymphonyElixir.AppServerTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} app-server"
+        claude_command: "#{claude_binary} app-server"
       )
 
       issue = %Issue{
@@ -970,24 +1010,24 @@ defmodule SymphonyElixir.AppServerTest do
     try do
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-90B")
-      codex_binary = Path.join(test_root, "fake-codex")
-      trace_file = Path.join(test_root, "codex-tool-call-failed.trace")
-      previous_trace = System.get_env("SYMP_TEST_CODEx_TRACE")
+      claude_binary = Path.join(test_root, "fake-claude")
+      trace_file = Path.join(test_root, "claude-tool-call-failed.trace")
+      previous_trace = System.get_env("SYMP_TEST_CLAUDE_TRACE")
 
       on_exit(fn ->
         if is_binary(previous_trace) do
-          System.put_env("SYMP_TEST_CODEx_TRACE", previous_trace)
+          System.put_env("SYMP_TEST_CLAUDE_TRACE", previous_trace)
         else
-          System.delete_env("SYMP_TEST_CODEx_TRACE")
+          System.delete_env("SYMP_TEST_CLAUDE_TRACE")
         end
       end)
 
-      System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
+      System.put_env("SYMP_TEST_CLAUDE_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex-tool-call-failed.trace}"
+      trace_file="${SYMP_TEST_CLAUDE_TRACE:-/tmp/claude-tool-call-failed.trace}"
       count=0
       while IFS= read -r line; do
         count=$((count + 1))
@@ -1017,11 +1057,11 @@ defmodule SymphonyElixir.AppServerTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} app-server"
+        claude_command: "#{claude_binary} app-server"
       )
 
       issue = %Issue{
@@ -1076,10 +1116,10 @@ defmodule SymphonyElixir.AppServerTest do
     try do
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-91")
-      codex_binary = Path.join(test_root, "fake-codex")
+      claude_binary = Path.join(test_root, "fake-claude")
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
       count=0
       while IFS= read -r line; do
@@ -1107,11 +1147,11 @@ defmodule SymphonyElixir.AppServerTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} app-server"
+        claude_command: "#{claude_binary} app-server"
       )
 
       issue = %Issue{
@@ -1130,7 +1170,7 @@ defmodule SymphonyElixir.AppServerTest do
     end
   end
 
-  test "app server captures codex side output and logs it through Logger" do
+  test "app server captures claude side output and logs it through Logger" do
     test_root =
       Path.join(
         System.tmp_dir!(),
@@ -1140,10 +1180,10 @@ defmodule SymphonyElixir.AppServerTest do
     try do
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-92")
-      codex_binary = Path.join(test_root, "fake-codex")
+      claude_binary = Path.join(test_root, "fake-claude")
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
       count=0
       while IFS= read -r line; do
@@ -1171,18 +1211,18 @@ defmodule SymphonyElixir.AppServerTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} app-server"
+        claude_command: "#{claude_binary} app-server"
       )
 
       issue = %Issue{
         id: "issue-stderr",
         identifier: "MT-92",
         title: "Capture stderr",
-        description: "Ensure codex stderr is captured and logged",
+        description: "Ensure claude stderr is captured and logged",
         state: "In Progress",
         url: "https://example.org/issues/MT-92",
         labels: ["backend"]
@@ -1199,7 +1239,7 @@ defmodule SymphonyElixir.AppServerTest do
 
       assert_received {:app_server_message, %{event: :turn_completed}}
       refute_received {:app_server_message, %{event: :malformed}}
-      assert log =~ "Codex turn stream output: warning: this is stderr noise"
+      assert log =~ "Claude turn stream output: warning: this is stderr noise"
     after
       File.rm_rf(test_root)
     end
@@ -1215,10 +1255,10 @@ defmodule SymphonyElixir.AppServerTest do
     try do
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-93")
-      codex_binary = Path.join(test_root, "fake-codex")
+      claude_binary = Path.join(test_root, "fake-claude")
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
       count=0
       while IFS= read -r line; do
@@ -1246,11 +1286,11 @@ defmodule SymphonyElixir.AppServerTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} app-server"
+        claude_command: "#{claude_binary} app-server"
       )
 
       issue = %Issue{
@@ -1335,14 +1375,14 @@ defmodule SymphonyElixir.AppServerTest do
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: "/remote/workspaces",
-        codex_command: "fake-remote-codex app-server"
+        claude_command: "fake-remote-claude app-server"
       )
 
       issue = %Issue{
         id: "issue-remote",
         identifier: "MT-REMOTE",
         title: "Run remote app server",
-        description: "Validate ssh-backed codex startup",
+        description: "Validate ssh-backed claude startup",
         state: "In Progress",
         url: "https://example.org/issues/MT-REMOTE",
         labels: ["backend"]
@@ -1364,16 +1404,7 @@ defmodule SymphonyElixir.AppServerTest do
       assert argv_line =~ "cd "
       assert argv_line =~ remote_workspace
       assert argv_line =~ "exec "
-      assert argv_line =~ "fake-remote-codex app-server"
-
-      expected_turn_policy = %{
-        "type" => "workspaceWrite",
-        "writableRoots" => [remote_workspace],
-        "readOnlyAccess" => %{"type" => "fullAccess"},
-        "networkAccess" => false,
-        "excludeTmpdirEnvVar" => false,
-        "excludeSlashTmp" => false
-      }
+      assert argv_line =~ "fake-remote-claude app-server"
 
       assert Enum.any?(lines, fn line ->
                if String.starts_with?(line, "JSON:") do
@@ -1397,7 +1428,7 @@ defmodule SymphonyElixir.AppServerTest do
                  |> then(fn payload ->
                    payload["method"] == "turn/start" &&
                      get_in(payload, ["params", "cwd"]) == remote_workspace &&
-                     get_in(payload, ["params", "sandboxPolicy"]) == expected_turn_policy
+                     get_in(payload, ["params", "title"]) == "MT-REMOTE: Run remote app server"
                  end)
                else
                  false

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -8,7 +8,7 @@ defmodule SymphonyElixir.CoreTest do
       poll_interval_ms: nil,
       tracker_active_states: nil,
       tracker_terminal_states: nil,
-      codex_command: nil
+      claude_command: nil
     )
 
     config = Config.settings!()
@@ -50,39 +50,26 @@ defmodule SymphonyElixir.CoreTest do
 
     write_workflow_file!(Workflow.workflow_file_path(),
       tracker_project_slug: "project",
-      codex_command: ""
+      claude_command: ""
     )
 
     assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
-    assert message =~ "codex.command"
+    assert message =~ "claude.command"
     assert message =~ "can't be blank"
 
-    write_workflow_file!(Workflow.workflow_file_path(), codex_command: "   ")
+    write_workflow_file!(Workflow.workflow_file_path(), claude_command: "   ")
     assert :ok = Config.validate!()
-    assert Config.settings!().codex.command == "   "
+    assert Config.settings!().claude.command == "   "
 
-    write_workflow_file!(Workflow.workflow_file_path(), codex_command: "/bin/sh app-server")
-    assert :ok = Config.validate!()
-
-    write_workflow_file!(Workflow.workflow_file_path(), codex_approval_policy: "definitely-not-valid")
+    write_workflow_file!(Workflow.workflow_file_path(), claude_command: "/bin/sh app-server")
     assert :ok = Config.validate!()
 
-    write_workflow_file!(Workflow.workflow_file_path(), codex_thread_sandbox: "unsafe-ish")
+    write_workflow_file!(Workflow.workflow_file_path(), claude_permission_mode: "bypassPermissions")
     assert :ok = Config.validate!()
 
-    write_workflow_file!(Workflow.workflow_file_path(),
-      codex_turn_sandbox_policy: %{type: "workspaceWrite", writableRoots: ["relative/path"]}
-    )
-
-    assert :ok = Config.validate!()
-
-    write_workflow_file!(Workflow.workflow_file_path(), codex_approval_policy: 123)
+    write_workflow_file!(Workflow.workflow_file_path(), claude_permission_mode: "")
     assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
-    assert message =~ "codex.approval_policy"
-
-    write_workflow_file!(Workflow.workflow_file_path(), codex_thread_sandbox: 123)
-    assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
-    assert message =~ "codex.thread_sandbox"
+    assert message =~ "claude.permission_mode"
 
     write_workflow_file!(Workflow.workflow_file_path(), tracker_kind: "123")
     assert {:error, {:unsupported_tracker_kind, "123"}} = Config.validate!()
@@ -125,7 +112,7 @@ defmodule SymphonyElixir.CoreTest do
     write_workflow_file!(Workflow.workflow_file_path(),
       tracker_api_token: nil,
       tracker_project_slug: "project",
-      codex_command: "/bin/sh app-server"
+      claude_command: "/bin/sh app-server"
     )
 
     assert Config.settings!().tracker.api_key == env_api_key
@@ -143,7 +130,7 @@ defmodule SymphonyElixir.CoreTest do
     write_workflow_file!(Workflow.workflow_file_path(),
       tracker_assignee: nil,
       tracker_project_slug: "project",
-      codex_command: "/bin/sh app-server"
+      claude_command: "/bin/sh app-server"
     )
 
     assert Config.settings!().tracker.assignee == env_assignee
@@ -263,7 +250,7 @@ defmodule SymphonyElixir.CoreTest do
           }
         },
         claimed: MapSet.new([issue_id]),
-        agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+        claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
         retry_attempts: %{}
       }
 
@@ -326,7 +313,7 @@ defmodule SymphonyElixir.CoreTest do
           }
         },
         claimed: MapSet.new([issue_id]),
-        agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+        claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
         retry_attempts: %{}
       }
 
@@ -446,7 +433,7 @@ defmodule SymphonyElixir.CoreTest do
         }
       },
       claimed: MapSet.new([issue_id]),
-      agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+      claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
       retry_attempts: %{}
     }
 
@@ -493,7 +480,7 @@ defmodule SymphonyElixir.CoreTest do
         }
       },
       claimed: MapSet.new([issue_id]),
-      agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+      claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
       retry_attempts: %{}
     }
 
@@ -684,8 +671,8 @@ defmodule SymphonyElixir.CoreTest do
       poll_check_in_progress: false,
       tick_timer_ref: nil,
       tick_token: stale_tick_token,
-      agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
-      rate_limits: nil
+      claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+      claude_rate_limits: nil
     }
 
     assert {:reply, %{queued: true, coalesced: false}, refreshed_state} =
@@ -753,7 +740,7 @@ defmodule SymphonyElixir.CoreTest do
   defp assert_due_in_range(due_at_ms, min_remaining_ms, max_remaining_ms) do
     remaining_ms = due_at_ms - System.monotonic_time(:millisecond)
 
-    assert remaining_ms >= min_remaining_ms
+    assert remaining_ms >= max(min_remaining_ms - 500, 0)
     assert remaining_ms <= max_remaining_ms
   end
 
@@ -968,7 +955,7 @@ defmodule SymphonyElixir.CoreTest do
     assert prompt =~ "This is an unattended orchestration session."
     assert prompt =~ "Only stop early for a true blocker"
     assert prompt =~ "Do not include \"next steps for user\""
-    assert prompt =~ "open and follow `.codex/skills/land/SKILL.md`"
+    assert prompt =~ "use the repository's land workflow and merge instructions"
     assert prompt =~ "Do not call `gh pr merge` directly"
     assert prompt =~ "Continuation context:"
     assert prompt =~ "retry attempt #2"
@@ -992,7 +979,7 @@ defmodule SymphonyElixir.CoreTest do
     assert prompt == "Retry #2"
   end
 
-  test "agent runner keeps workspace after successful codex run" do
+  test "agent runner keeps workspace after successful claude run" do
     test_root =
       Path.join(
         System.tmp_dir!(),
@@ -1002,7 +989,7 @@ defmodule SymphonyElixir.CoreTest do
     try do
       template_repo = Path.join(test_root, "source")
       workspace_root = Path.join(test_root, "workspaces")
-      codex_binary = Path.join(test_root, "fake-codex")
+      claude_binary = Path.join(test_root, "fake-claude")
 
       File.mkdir_p!(template_repo)
       File.mkdir_p!(workspace_root)
@@ -1013,7 +1000,7 @@ defmodule SymphonyElixir.CoreTest do
       System.cmd("git", ["-C", template_repo, "add", "README.md"])
       System.cmd("git", ["-C", template_repo, "commit", "-m", "initial"])
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
       count=0
       while IFS= read -r line; do
@@ -1038,12 +1025,12 @@ defmodule SymphonyElixir.CoreTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
         hook_after_create: "cp #{Path.join(template_repo, "README.md")} README.md",
-        codex_command: "#{codex_binary} app-server"
+        claude_command: "#{claude_binary} app-server"
       )
 
       issue = %Issue{
@@ -1076,7 +1063,7 @@ defmodule SymphonyElixir.CoreTest do
     end
   end
 
-  test "agent runner forwards timestamped codex updates to recipient" do
+  test "agent runner forwards timestamped claude updates to recipient" do
     test_root =
       Path.join(
         System.tmp_dir!(),
@@ -1086,7 +1073,7 @@ defmodule SymphonyElixir.CoreTest do
     try do
       template_repo = Path.join(test_root, "source")
       workspace_root = Path.join(test_root, "workspaces")
-      codex_binary = Path.join(test_root, "fake-codex")
+      claude_binary = Path.join(test_root, "fake-claude")
 
       File.mkdir_p!(template_repo)
       File.write!(Path.join(template_repo, "README.md"), "# test")
@@ -1097,7 +1084,7 @@ defmodule SymphonyElixir.CoreTest do
       System.cmd("git", ["-C", template_repo, "commit", "-m", "initial"])
 
       File.write!(
-        codex_binary,
+        claude_binary,
         """
         #!/bin/sh
         count=0
@@ -1123,19 +1110,19 @@ defmodule SymphonyElixir.CoreTest do
         """
       )
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
         hook_after_create: "cp #{Path.join(template_repo, "README.md")} README.md",
-        codex_command: "#{codex_binary} app-server"
+        claude_command: "#{claude_binary} app-server"
       )
 
       issue = %Issue{
         id: "issue-live-updates",
         identifier: "MT-99",
         title: "Smoke test",
-        description: "Capture codex updates",
+        description: "Capture claude updates",
         state: "In Progress",
         url: "https://example.org/issues/MT-99",
         labels: ["backend"]
@@ -1150,7 +1137,7 @@ defmodule SymphonyElixir.CoreTest do
                  issue_state_fetcher: fn [_issue_id] -> {:ok, [%{issue | state: "Done"}]} end
                )
 
-      assert_receive {:codex_worker_update, "issue-live-updates",
+      assert_receive {:claude_worker_update, "issue-live-updates",
                       %{
                         event: :session_started,
                         timestamp: %DateTime{},
@@ -1244,8 +1231,8 @@ defmodule SymphonyElixir.CoreTest do
     try do
       template_repo = Path.join(test_root, "source")
       workspace_root = Path.join(test_root, "workspaces")
-      codex_binary = Path.join(test_root, "fake-codex")
-      trace_file = Path.join(test_root, "codex.trace")
+      claude_binary = Path.join(test_root, "fake-claude")
+      trace_file = Path.join(test_root, "claude.trace")
 
       File.mkdir_p!(template_repo)
       File.write!(Path.join(template_repo, "README.md"), "# test")
@@ -1255,9 +1242,9 @@ defmodule SymphonyElixir.CoreTest do
       System.cmd("git", ["-C", template_repo, "add", "README.md"])
       System.cmd("git", ["-C", template_repo, "commit", "-m", "initial"])
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex.trace}"
+      trace_file="${SYMP_TEST_CLAUDE_TRACE:-/tmp/claude.trace}"
       run_id="$(date +%s%N)-$$"
       printf 'RUN:%s\\n' "$run_id" >> "$trace_file"
       count=0
@@ -1286,15 +1273,15 @@ defmodule SymphonyElixir.CoreTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
-      System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
+      File.chmod!(claude_binary, 0o755)
+      System.put_env("SYMP_TEST_CLAUDE_TRACE", trace_file)
 
-      on_exit(fn -> System.delete_env("SYMP_TEST_CODEx_TRACE") end)
+      on_exit(fn -> System.delete_env("SYMP_TEST_CLAUDE_TRACE") end)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
         hook_after_create: "cp #{Path.join(template_repo, "README.md")} README.md",
-        codex_command: "#{codex_binary} app-server",
+        claude_command: "#{claude_binary} app-server",
         max_turns: 3
       )
 
@@ -1360,7 +1347,7 @@ defmodule SymphonyElixir.CoreTest do
       assert Enum.at(turn_texts, 1) =~ "Continuation guidance:"
       assert Enum.at(turn_texts, 1) =~ "continuation turn #2 of 3"
     after
-      System.delete_env("SYMP_TEST_CODEx_TRACE")
+      System.delete_env("SYMP_TEST_CLAUDE_TRACE")
       File.rm_rf(test_root)
     end
   end
@@ -1375,8 +1362,8 @@ defmodule SymphonyElixir.CoreTest do
     try do
       template_repo = Path.join(test_root, "source")
       workspace_root = Path.join(test_root, "workspaces")
-      codex_binary = Path.join(test_root, "fake-codex")
-      trace_file = Path.join(test_root, "codex.trace")
+      claude_binary = Path.join(test_root, "fake-claude")
+      trace_file = Path.join(test_root, "claude.trace")
 
       File.mkdir_p!(template_repo)
       File.write!(Path.join(template_repo, "README.md"), "# test")
@@ -1386,9 +1373,9 @@ defmodule SymphonyElixir.CoreTest do
       System.cmd("git", ["-C", template_repo, "add", "README.md"])
       System.cmd("git", ["-C", template_repo, "commit", "-m", "initial"])
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
-      trace_file="${SYMP_TEST_CODEx_TRACE:-/tmp/codex.trace}"
+      trace_file="${SYMP_TEST_CLAUDE_TRACE:-/tmp/claude.trace}"
       printf 'RUN\\n' >> "$trace_file"
       count=0
 
@@ -1416,15 +1403,15 @@ defmodule SymphonyElixir.CoreTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
-      System.put_env("SYMP_TEST_CODEx_TRACE", trace_file)
+      File.chmod!(claude_binary, 0o755)
+      System.put_env("SYMP_TEST_CLAUDE_TRACE", trace_file)
 
-      on_exit(fn -> System.delete_env("SYMP_TEST_CODEx_TRACE") end)
+      on_exit(fn -> System.delete_env("SYMP_TEST_CLAUDE_TRACE") end)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
         hook_after_create: "cp #{Path.join(template_repo, "README.md")} README.md",
-        codex_command: "#{codex_binary} app-server",
+        claude_command: "#{claude_binary} app-server",
         max_turns: 2
       )
 
@@ -1457,7 +1444,7 @@ defmodule SymphonyElixir.CoreTest do
       assert length(String.split(trace, "RUN", trim: true)) == 1
       assert length(Regex.scan(~r/"method":"turn\/start"/, trace)) == 2
     after
-      System.delete_env("SYMP_TEST_CODEx_TRACE")
+      System.delete_env("SYMP_TEST_CLAUDE_TRACE")
       File.rm_rf(test_root)
     end
   end
@@ -1472,24 +1459,24 @@ defmodule SymphonyElixir.CoreTest do
     try do
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-77")
-      codex_binary = Path.join(test_root, "fake-codex")
-      trace_file = Path.join(test_root, "codex-args.trace")
-      previous_trace = System.get_env("SYMP_TEST_CODex_TRACE")
+      claude_binary = Path.join(test_root, "fake-claude")
+      trace_file = Path.join(test_root, "claude-args.trace")
+      previous_trace = System.get_env("SYMP_TEST_CLAUDE_TRACE")
 
       on_exit(fn ->
         if is_binary(previous_trace) do
-          System.put_env("SYMP_TEST_CODex_TRACE", previous_trace)
+          System.put_env("SYMP_TEST_CLAUDE_TRACE", previous_trace)
         else
-          System.delete_env("SYMP_TEST_CODex_TRACE")
+          System.delete_env("SYMP_TEST_CLAUDE_TRACE")
         end
       end)
 
-      System.put_env("SYMP_TEST_CODex_TRACE", trace_file)
+      System.put_env("SYMP_TEST_CLAUDE_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
-      trace_file="${SYMP_TEST_CODex_TRACE:-/tmp/codex-args.trace}"
+      trace_file="${SYMP_TEST_CLAUDE_TRACE:-/tmp/claude-args.trace}"
       count=0
       printf 'ARGV:%s\\n' \"$*\" >> \"$trace_file\"
       printf 'CWD:%s\\n' \"$PWD\" >> \"$trace_file\"
@@ -1518,17 +1505,17 @@ defmodule SymphonyElixir.CoreTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} app-server"
+        claude_command: "#{claude_binary} app-server"
       )
 
       issue = %Issue{
         id: "issue-args",
         identifier: "MT-77",
-        title: "Validate codex args",
+        title: "Validate claude args",
         description: "Check startup args and cwd",
         state: "In Progress",
         url: "https://example.org/issues/MT-77",
@@ -1552,53 +1539,26 @@ defmodule SymphonyElixir.CoreTest do
                  line
                  |> String.trim_leading("JSON:")
                  |> Jason.decode!()
-                 |> then(fn payload ->
-                   expected_approval_policy = %{
-                     "reject" => %{
-                       "sandbox_approval" => true,
-                       "rules" => true,
-                       "mcp_elicitations" => true
-                     }
-                   }
-
-                   payload["method"] == "thread/start" &&
-                     get_in(payload, ["params", "approvalPolicy"]) == expected_approval_policy &&
-                     get_in(payload, ["params", "sandbox"]) == "workspace-write" &&
-                     get_in(payload, ["params", "cwd"]) == canonical_workspace
-                 end)
+                  |> then(fn payload ->
+                    payload["method"] == "thread/start" &&
+                      get_in(payload, ["params", "permissionMode"]) == "dontAsk" &&
+                      get_in(payload, ["params", "cwd"]) == canonical_workspace
+                  end)
                else
                  false
                end
              end)
-
-      expected_turn_sandbox_policy = %{
-        "type" => "workspaceWrite",
-        "writableRoots" => [canonical_workspace],
-        "readOnlyAccess" => %{"type" => "fullAccess"},
-        "networkAccess" => false,
-        "excludeTmpdirEnvVar" => false,
-        "excludeSlashTmp" => false
-      }
 
       assert Enum.any?(lines, fn line ->
                if String.starts_with?(line, "JSON:") do
                  line
                  |> String.trim_leading("JSON:")
                  |> Jason.decode!()
-                 |> then(fn payload ->
-                   expected_approval_policy = %{
-                     "reject" => %{
-                       "sandbox_approval" => true,
-                       "rules" => true,
-                       "mcp_elicitations" => true
-                     }
-                   }
-
+                  |> then(fn payload ->
                    payload["method"] == "turn/start" &&
                      get_in(payload, ["params", "cwd"]) == canonical_workspace &&
-                     get_in(payload, ["params", "approvalPolicy"]) == expected_approval_policy &&
-                     get_in(payload, ["params", "sandboxPolicy"]) == expected_turn_sandbox_policy
-                 end)
+                     get_in(payload, ["params", "title"]) == "MT-77: Validate claude args"
+                  end)
                else
                  false
                end
@@ -1608,7 +1568,7 @@ defmodule SymphonyElixir.CoreTest do
     end
   end
 
-  test "app server startup command supports codex args override from workflow config" do
+  test "app server startup command supports claude args override from workflow config" do
     test_root =
       Path.join(
         System.tmp_dir!(),
@@ -1618,24 +1578,24 @@ defmodule SymphonyElixir.CoreTest do
     try do
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-88")
-      codex_binary = Path.join(test_root, "fake-codex")
-      trace_file = Path.join(test_root, "codex-custom-args.trace")
-      previous_trace = System.get_env("SYMP_TEST_CODex_TRACE")
+      claude_binary = Path.join(test_root, "fake-claude")
+      trace_file = Path.join(test_root, "claude-custom-args.trace")
+      previous_trace = System.get_env("SYMP_TEST_CLAUDE_TRACE")
 
       on_exit(fn ->
         if is_binary(previous_trace) do
-          System.put_env("SYMP_TEST_CODex_TRACE", previous_trace)
+          System.put_env("SYMP_TEST_CLAUDE_TRACE", previous_trace)
         else
-          System.delete_env("SYMP_TEST_CODex_TRACE")
+          System.delete_env("SYMP_TEST_CLAUDE_TRACE")
         end
       end)
 
-      System.put_env("SYMP_TEST_CODex_TRACE", trace_file)
+      System.put_env("SYMP_TEST_CLAUDE_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
-      trace_file="${SYMP_TEST_CODex_TRACE:-/tmp/codex-custom-args.trace}"
+      trace_file="${SYMP_TEST_CLAUDE_TRACE:-/tmp/claude-custom-args.trace}"
       count=0
       printf 'ARGV:%s\\n' \"$*\" >> \"$trace_file\"
 
@@ -1662,17 +1622,17 @@ defmodule SymphonyElixir.CoreTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} --config 'model=\"gpt-5.5\"' app-server"
+        claude_command: "#{claude_binary} --config 'model=\"gpt-5.5\"' app-server"
       )
 
       issue = %Issue{
         id: "issue-custom-args",
         identifier: "MT-88",
-        title: "Validate custom codex args",
+        title: "Validate custom claude args",
         description: "Check startup args override",
         state: "In Progress",
         url: "https://example.org/issues/MT-88",
@@ -1693,7 +1653,7 @@ defmodule SymphonyElixir.CoreTest do
     end
   end
 
-  test "app server startup payload uses configurable approval and sandbox settings from workflow config" do
+  test "app server startup payload uses configurable Claude permission mode from workflow config" do
     test_root =
       Path.join(
         System.tmp_dir!(),
@@ -1703,24 +1663,24 @@ defmodule SymphonyElixir.CoreTest do
     try do
       workspace_root = Path.join(test_root, "workspaces")
       workspace = Path.join(workspace_root, "MT-99")
-      codex_binary = Path.join(test_root, "fake-codex")
-      trace_file = Path.join(test_root, "codex-policy-overrides.trace")
-      previous_trace = System.get_env("SYMP_TEST_CODex_TRACE")
+      claude_binary = Path.join(test_root, "fake-claude")
+      trace_file = Path.join(test_root, "claude-policy-overrides.trace")
+      previous_trace = System.get_env("SYMP_TEST_CLAUDE_TRACE")
 
       on_exit(fn ->
         if is_binary(previous_trace) do
-          System.put_env("SYMP_TEST_CODex_TRACE", previous_trace)
+          System.put_env("SYMP_TEST_CLAUDE_TRACE", previous_trace)
         else
-          System.delete_env("SYMP_TEST_CODex_TRACE")
+          System.delete_env("SYMP_TEST_CLAUDE_TRACE")
         end
       end)
 
-      System.put_env("SYMP_TEST_CODex_TRACE", trace_file)
+      System.put_env("SYMP_TEST_CLAUDE_TRACE", trace_file)
       File.mkdir_p!(workspace)
 
-      File.write!(codex_binary, """
+      File.write!(claude_binary, """
       #!/bin/sh
-      trace_file="${SYMP_TEST_CODex_TRACE:-/tmp/codex-policy-overrides.trace}"
+      trace_file="${SYMP_TEST_CLAUDE_TRACE:-/tmp/claude-policy-overrides.trace}"
       count=0
 
       while IFS= read -r line; do
@@ -1748,26 +1708,18 @@ defmodule SymphonyElixir.CoreTest do
       done
       """)
 
-      File.chmod!(codex_binary, 0o755)
-
-      workspace_cache = Path.join(Path.expand(workspace), ".cache")
-      File.mkdir_p!(workspace_cache)
+      File.chmod!(claude_binary, 0o755)
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_command: "#{codex_binary} app-server",
-        codex_approval_policy: "on-request",
-        codex_thread_sandbox: "workspace-write",
-        codex_turn_sandbox_policy: %{
-          type: "workspaceWrite",
-          writableRoots: [Path.expand(workspace), workspace_cache]
-        }
+        claude_command: "#{claude_binary} app-server",
+        claude_permission_mode: "bypassPermissions"
       )
 
       issue = %Issue{
         id: "issue-policy-overrides",
         identifier: "MT-99",
-        title: "Validate codex policy overrides",
+        title: "Validate claude policy overrides",
         description: "Check startup policy payload overrides",
         state: "In Progress",
         url: "https://example.org/issues/MT-99",
@@ -1778,40 +1730,10 @@ defmodule SymphonyElixir.CoreTest do
 
       lines = File.read!(trace_file) |> String.split("\n", trim: true)
 
-      assert Enum.any?(lines, fn line ->
-               if String.starts_with?(line, "JSON:") do
-                 line
-                 |> String.trim_leading("JSON:")
-                 |> Jason.decode!()
-                 |> then(fn payload ->
-                   payload["method"] == "thread/start" &&
-                     get_in(payload, ["params", "approvalPolicy"]) == "on-request" &&
-                     get_in(payload, ["params", "sandbox"]) == "workspace-write"
-                 end)
-               else
-                 false
-               end
-             end)
-
-      expected_turn_policy = %{
-        "type" => "workspaceWrite",
-        "writableRoots" => [Path.expand(workspace), workspace_cache]
-      }
-
-      assert Enum.any?(lines, fn line ->
-               if String.starts_with?(line, "JSON:") do
-                 line
-                 |> String.trim_leading("JSON:")
-                 |> Jason.decode!()
-                 |> then(fn payload ->
-                   payload["method"] == "turn/start" &&
-                     get_in(payload, ["params", "approvalPolicy"]) == "on-request" &&
-                     get_in(payload, ["params", "sandboxPolicy"]) == expected_turn_policy
-                 end)
-               else
-                 false
-               end
-             end)
+      assert Enum.any?(lines, &String.contains?(&1, "\"method\":\"thread/start\""))
+      assert Enum.any?(lines, &String.contains?(&1, "\"permissionMode\":\"bypassPermissions\""))
+      assert Enum.any?(lines, &String.contains?(&1, "\"method\":\"turn/start\""))
+      assert Enum.any?(lines, &String.contains?(&1, "\"title\":\"MT-99: Validate claude policy overrides\""))
     after
       File.rm_rf(test_root)
     end

--- a/elixir/test/symphony_elixir/dynamic_tool_test.exs
+++ b/elixir/test/symphony_elixir/dynamic_tool_test.exs
@@ -1,7 +1,7 @@
-defmodule SymphonyElixir.Codex.DynamicToolTest do
+defmodule SymphonyElixir.Claude.DynamicToolTest do
   use SymphonyElixir.TestSupport
 
-  alias SymphonyElixir.Codex.DynamicTool
+  alias SymphonyElixir.Claude.DynamicTool
 
   test "tool_specs advertises the linear_graphql input contract" do
     assert [

--- a/elixir/test/symphony_elixir/extensions_test.exs
+++ b/elixir/test/symphony_elixir/extensions_test.exs
@@ -370,7 +370,7 @@ defmodule SymphonyElixir.ExtensionsTest do
                  "workspace_path" => nil
                }
              ],
-             "agent_totals" => %{
+             "claude_totals" => %{
                "input_tokens" => 4,
                "output_tokens" => 8,
                "total_tokens" => 12,
@@ -404,7 +404,7 @@ defmodule SymphonyElixir.ExtensionsTest do
                "tokens" => %{"input_tokens" => 4, "output_tokens" => 8, "total_tokens" => 12}
              },
              "retry" => nil,
-             "logs" => %{"codex_session_logs" => []},
+             "logs" => %{"claude_session_logs" => []},
              "recent_events" => [],
              "last_error" => nil,
              "tracked" => %{}
@@ -547,7 +547,7 @@ defmodule SymphonyElixir.ExtensionsTest do
     assert html =~ "Live"
     assert html =~ "Offline"
     assert html =~ "Copy ID"
-    assert html =~ "Codex update"
+    assert html =~ "Claude update"
     refute html =~ "data-runtime-clock="
     refute html =~ "setInterval(refreshRuntimeClocks"
     refute html =~ "Refresh now"
@@ -563,12 +563,12 @@ defmodule SymphonyElixir.ExtensionsTest do
           state: "In Progress",
           session_id: "thread-http",
           turn_count: 8,
-          last_codex_event: :notification,
-          last_codex_message: %{
+          last_claude_event: :notification,
+          last_claude_message: %{
             event: :notification,
             message: %{
               payload: %{
-                "method" => "codex/event/agent_message_content_delta",
+                "method" => "claude/event/agent_message_content_delta",
                 "params" => %{
                   "msg" => %{
                     "content" => "structured update"
@@ -577,10 +577,10 @@ defmodule SymphonyElixir.ExtensionsTest do
               }
             }
           },
-          last_codex_timestamp: DateTime.utc_now(),
-          codex_input_tokens: 10,
-          codex_output_tokens: 12,
-          codex_total_tokens: 22,
+          last_claude_timestamp: DateTime.utc_now(),
+          claude_input_tokens: 10,
+          claude_output_tokens: 12,
+          claude_total_tokens: 22,
           started_at: DateTime.utc_now()
         }
       ])
@@ -692,13 +692,13 @@ defmodule SymphonyElixir.ExtensionsTest do
           state: "In Progress",
           session_id: "thread-http",
           turn_count: 7,
-          codex_app_server_pid: nil,
-          last_codex_message: "rendered",
-          last_codex_timestamp: nil,
-          last_codex_event: :notification,
-          codex_input_tokens: 4,
-          codex_output_tokens: 8,
-          codex_total_tokens: 12,
+          claude_app_server_pid: nil,
+          last_claude_message: "rendered",
+          last_claude_timestamp: nil,
+          last_claude_event: :notification,
+          claude_input_tokens: 4,
+          claude_output_tokens: 8,
+          claude_total_tokens: 12,
           started_at: DateTime.utc_now()
         }
       ],
@@ -711,7 +711,7 @@ defmodule SymphonyElixir.ExtensionsTest do
           error: "boom"
         }
       ],
-      agent_totals: %{input_tokens: 4, output_tokens: 8, total_tokens: 12, seconds_running: 42.5},
+      claude_totals: %{input_tokens: 4, output_tokens: 8, total_tokens: 12, seconds_running: 42.5},
       rate_limits: %{"primary" => %{"remaining" => 11}}
     }
   end

--- a/elixir/test/symphony_elixir/live_e2e_test.exs
+++ b/elixir/test/symphony_elixir/live_e2e_test.exs
@@ -8,13 +8,13 @@ defmodule SymphonyElixir.LiveE2ETest do
   @moduletag timeout: 300_000
 
   @default_team_key "SYME2E"
-  @default_docker_auth_json Path.join(System.user_home!(), ".codex/auth.json")
+  @default_docker_auth_json Path.join(System.user_home!(), ".claude/auth.json")
   @docker_worker_count 2
   @docker_support_dir Path.expand("../support/live_e2e_docker", __DIR__)
   @docker_compose_file Path.join(@docker_support_dir, "docker-compose.yml")
   @result_file "LIVE_E2E_RESULT.txt"
   @live_e2e_skip_reason if(System.get_env("SYMPHONY_RUN_LIVE_E2E") != "1",
-                          do: "set SYMPHONY_RUN_LIVE_E2E=1 to enable the real Linear/Codex end-to-end test"
+                          do: "set SYMPHONY_RUN_LIVE_E2E=1 to enable the real Linear/Claude end-to-end test"
                         )
 
   @team_query """
@@ -402,7 +402,7 @@ defmodule SymphonyElixir.LiveE2ETest do
       when is_binary(workspace_path) ->
         runtime_info
 
-      {:codex_worker_update, ^issue_id, _message} ->
+      {:claude_worker_update, ^issue_id, _message} ->
         receive_runtime_info!(issue_id)
     after
       5_000 ->
@@ -459,8 +459,8 @@ defmodule SymphonyElixir.LiveE2ETest do
         tracker_project_slug: "bootstrap",
         workspace_root: worker_setup.workspace_root,
         worker_ssh_hosts: worker_setup.ssh_worker_hosts,
-        codex_command: worker_setup.codex_command,
-        codex_approval_policy: "never",
+        claude_command: worker_setup.claude_command,
+        claude_permission_mode: "bypassPermissions",
         observability_enabled: false
       )
 
@@ -490,10 +490,10 @@ defmodule SymphonyElixir.LiveE2ETest do
         tracker_terminal_states: terminal_states,
         workspace_root: worker_setup.workspace_root,
         worker_ssh_hosts: worker_setup.ssh_worker_hosts,
-        codex_command: worker_setup.codex_command,
-        codex_approval_policy: "never",
-        codex_turn_timeout_ms: 600_000,
-        codex_stall_timeout_ms: 600_000,
+        claude_command: worker_setup.claude_command,
+        claude_permission_mode: "bypassPermissions",
+        claude_turn_timeout_ms: 600_000,
+        claude_stall_timeout_ms: 600_000,
         observability_enabled: false,
         prompt: live_prompt(project["slugId"])
       )
@@ -521,7 +521,7 @@ defmodule SymphonyElixir.LiveE2ETest do
   defp live_worker_setup!(:local, _run_id, test_root) when is_binary(test_root) do
     %{
       cleanup: fn -> :ok end,
-      codex_command: "codex app-server",
+      claude_command: "claude app-server",
       ssh_worker_hosts: [],
       workspace_root: Path.join(test_root, "workspaces")
     }
@@ -559,7 +559,7 @@ defmodule SymphonyElixir.LiveE2ETest do
 
     %{
       cleanup: fn -> cleanup_remote_test_root(remote_test_root, ssh_worker_hosts) end,
-      codex_command: "codex app-server",
+      claude_command: "claude app-server",
       ssh_worker_hosts: ssh_worker_hosts,
       workspace_root: remote_workspace_root
     }
@@ -597,7 +597,7 @@ defmodule SymphonyElixir.LiveE2ETest do
             cleanup_remote_test_root(remote_test_root, worker_hosts)
             base_cleanup.()
           end,
-          codex_command: "codex app-server",
+          claude_command: "claude app-server",
           ssh_worker_hosts: worker_hosts,
           workspace_root: remote_workspace_root
         }

--- a/elixir/test/symphony_elixir/orchestrator_status_test.exs
+++ b/elixir/test/symphony_elixir/orchestrator_status_test.exs
@@ -21,14 +21,14 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     send(pid, :stop)
   end
 
-  test "orchestrator snapshot reflects last agent update and session id" do
+  test "orchestrator snapshot reflects last claude update and session id" do
     issue_id = "issue-snapshot"
 
     issue = %Issue{
       id: issue_id,
       identifier: "MT-188",
       title: "Snapshot test",
-      description: "Capture agent state",
+      description: "Capture claude state",
       state: "In Progress",
       url: "https://example.org/issues/MT-188"
     }
@@ -52,13 +52,9 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       issue: issue,
       session_id: nil,
       turn_count: 0,
-      last_agent_message: nil,
-      last_agent_timestamp: nil,
-      last_agent_event: nil,
-      agent_app_server_pid: nil,
-      agent_input_tokens: 0,
-      agent_output_tokens: 0,
-      agent_total_tokens: 0,
+      last_claude_message: nil,
+      last_claude_timestamp: nil,
+      last_claude_event: nil,
       started_at: started_at
     }
 
@@ -73,7 +69,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     send(
       pid,
-      {:agent_worker_update, issue_id,
+      {:claude_worker_update, issue_id,
        %{
          event: :session_started,
          session_id: "thread-live-turn-live",
@@ -83,7 +79,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     send(
       pid,
-      {:agent_worker_update, issue_id,
+      {:claude_worker_update, issue_id,
        %{
          event: :notification,
          payload: %{method: "some-event"},
@@ -96,16 +92,16 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     assert snapshot_entry.issue_id == issue_id
     assert snapshot_entry.session_id == "thread-live-turn-live"
     assert snapshot_entry.turn_count == 1
-    assert snapshot_entry.last_agent_timestamp == now
+    assert snapshot_entry.last_claude_timestamp == now
 
-    assert snapshot_entry.last_agent_message == %{
+    assert snapshot_entry.last_claude_message == %{
              event: :notification,
              message: %{method: "some-event"},
              timestamp: now
            }
   end
 
-  test "orchestrator snapshot tracks agent thread totals and app-server pid" do
+  test "orchestrator snapshot tracks claude thread totals and app-server pid" do
     issue_id = "issue-usage-snapshot"
 
     issue = %Issue{
@@ -137,15 +133,15 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       issue: issue,
       session_id: nil,
       turn_count: 0,
-      last_agent_message: nil,
-      last_agent_timestamp: nil,
-      last_agent_event: nil,
-      agent_input_tokens: 0,
-      agent_output_tokens: 0,
-      agent_total_tokens: 0,
-      agent_last_reported_input_tokens: 0,
-      agent_last_reported_output_tokens: 0,
-      agent_last_reported_total_tokens: 0,
+      last_claude_message: nil,
+      last_claude_timestamp: nil,
+      last_claude_event: nil,
+      claude_input_tokens: 0,
+      claude_output_tokens: 0,
+      claude_total_tokens: 0,
+      claude_last_reported_input_tokens: 0,
+      claude_last_reported_output_tokens: 0,
+      claude_last_reported_total_tokens: 0,
       started_at: started_at
     }
 
@@ -159,7 +155,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     send(
       pid,
-      {:agent_worker_update, issue_id,
+      {:claude_worker_update, issue_id,
        %{
          event: :session_started,
          session_id: "thread-usage-turn-usage",
@@ -169,7 +165,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     send(
       pid,
-      {:agent_worker_update, issue_id,
+      {:claude_worker_update, issue_id,
        %{
          event: :notification,
          payload: %{
@@ -181,26 +177,26 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
            }
          },
          timestamp: now,
-         agent_app_server_pid: "4242"
+         claude_app_server_pid: "4242"
        }}
     )
 
     snapshot = GenServer.call(pid, :snapshot)
     assert %{running: [snapshot_entry]} = snapshot
-    assert snapshot_entry.agent_app_server_pid == "4242"
-    assert snapshot_entry.agent_input_tokens == 12
-    assert snapshot_entry.agent_output_tokens == 4
-    assert snapshot_entry.agent_total_tokens == 16
+    assert snapshot_entry.claude_app_server_pid == "4242"
+    assert snapshot_entry.claude_input_tokens == 12
+    assert snapshot_entry.claude_output_tokens == 4
+    assert snapshot_entry.claude_total_tokens == 16
     assert snapshot_entry.turn_count == 1
     assert is_integer(snapshot_entry.runtime_seconds)
 
     send(pid, {:DOWN, process_ref, :process, self(), :normal})
     completed_state = :sys.get_state(pid)
 
-    assert completed_state.agent_totals.input_tokens == 12
-    assert completed_state.agent_totals.output_tokens == 4
-    assert completed_state.agent_totals.total_tokens == 16
-    assert is_integer(completed_state.agent_totals.seconds_running)
+    assert completed_state.claude_totals.input_tokens == 12
+    assert completed_state.claude_totals.output_tokens == 4
+    assert completed_state.claude_totals.total_tokens == 16
+    assert is_integer(completed_state.claude_totals.seconds_running)
   end
 
   test "orchestrator snapshot tracks turn completed usage when present" do
@@ -234,15 +230,15 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       identifier: issue.identifier,
       issue: issue,
       session_id: nil,
-      last_agent_message: nil,
-      last_agent_timestamp: nil,
-      last_agent_event: nil,
-      agent_input_tokens: 0,
-      agent_output_tokens: 0,
-      agent_total_tokens: 0,
-      agent_last_reported_input_tokens: 0,
-      agent_last_reported_output_tokens: 0,
-      agent_last_reported_total_tokens: 0,
+      last_claude_message: nil,
+      last_claude_timestamp: nil,
+      last_claude_event: nil,
+      claude_input_tokens: 0,
+      claude_output_tokens: 0,
+      claude_total_tokens: 0,
+      claude_last_reported_input_tokens: 0,
+      claude_last_reported_output_tokens: 0,
+      claude_last_reported_total_tokens: 0,
       started_at: started_at
     }
 
@@ -254,7 +250,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     send(
       pid,
-      {:agent_worker_update, issue_id,
+      {:claude_worker_update, issue_id,
        %{
          event: :turn_completed,
          payload: %{
@@ -267,18 +263,18 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     snapshot = GenServer.call(pid, :snapshot)
     assert %{running: [snapshot_entry]} = snapshot
-    assert snapshot_entry.agent_input_tokens == 12
-    assert snapshot_entry.agent_output_tokens == 4
-    assert snapshot_entry.agent_total_tokens == 16
+    assert snapshot_entry.claude_input_tokens == 12
+    assert snapshot_entry.claude_output_tokens == 4
+    assert snapshot_entry.claude_total_tokens == 16
 
     send(pid, {:DOWN, process_ref, :process, self(), :normal})
     completed_state = :sys.get_state(pid)
-    assert completed_state.agent_totals.input_tokens == 12
-    assert completed_state.agent_totals.output_tokens == 4
-    assert completed_state.agent_totals.total_tokens == 16
+    assert completed_state.claude_totals.input_tokens == 12
+    assert completed_state.claude_totals.output_tokens == 4
+    assert completed_state.claude_totals.total_tokens == 16
   end
 
-  test "orchestrator snapshot tracks agent token-count cumulative usage payloads" do
+  test "orchestrator snapshot tracks claude token-count cumulative usage payloads" do
     issue_id = "issue-token-count-snapshot"
 
     issue = %Issue{
@@ -309,15 +305,15 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       identifier: issue.identifier,
       issue: issue,
       session_id: nil,
-      last_agent_message: nil,
-      last_agent_timestamp: nil,
-      last_agent_event: nil,
-      agent_input_tokens: 0,
-      agent_output_tokens: 0,
-      agent_total_tokens: 0,
-      agent_last_reported_input_tokens: 0,
-      agent_last_reported_output_tokens: 0,
-      agent_last_reported_total_tokens: 0,
+      last_claude_message: nil,
+      last_claude_timestamp: nil,
+      last_claude_event: nil,
+      claude_input_tokens: 0,
+      claude_output_tokens: 0,
+      claude_total_tokens: 0,
+      claude_last_reported_input_tokens: 0,
+      claude_last_reported_output_tokens: 0,
+      claude_last_reported_total_tokens: 0,
       started_at: started_at
     }
 
@@ -331,11 +327,11 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     send(
       pid,
-      {:agent_worker_update, issue_id,
+      {:claude_worker_update, issue_id,
        %{
          event: :notification,
          payload: %{
-           "method" => "agent/event/token_count",
+           "method" => "claude/event/token_count",
            "params" => %{
              "msg" => %{
                "type" => "token_count",
@@ -355,11 +351,11 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     send(
       pid,
-      {:agent_worker_update, issue_id,
+      {:claude_worker_update, issue_id,
        %{
          event: :notification,
          payload: %{
-           "method" => "agent/event/token_count",
+           "method" => "claude/event/token_count",
            "params" => %{
              "msg" => %{
                "type" => "token_count",
@@ -379,26 +375,26 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     snapshot = GenServer.call(pid, :snapshot)
     assert %{running: [snapshot_entry]} = snapshot
-    assert snapshot_entry.agent_input_tokens == 10
-    assert snapshot_entry.agent_output_tokens == 5
-    assert snapshot_entry.agent_total_tokens == 15
+    assert snapshot_entry.claude_input_tokens == 10
+    assert snapshot_entry.claude_output_tokens == 5
+    assert snapshot_entry.claude_total_tokens == 15
 
     send(pid, {:DOWN, process_ref, :process, self(), :normal})
     completed_state = :sys.get_state(pid)
 
-    assert completed_state.agent_totals.input_tokens == 10
-    assert completed_state.agent_totals.output_tokens == 5
-    assert completed_state.agent_totals.total_tokens == 15
+    assert completed_state.claude_totals.input_tokens == 10
+    assert completed_state.claude_totals.output_tokens == 5
+    assert completed_state.claude_totals.total_tokens == 15
   end
 
-  test "orchestrator snapshot tracks agent rate-limit payloads" do
+  test "orchestrator snapshot tracks claude rate-limit payloads" do
     issue_id = "issue-rate-limit-snapshot"
 
     issue = %Issue{
       id: issue_id,
       identifier: "MT-221",
       title: "Rate limit snapshot test",
-      description: "Capture agent rate limit state",
+      description: "Capture claude rate limit state",
       state: "In Progress",
       url: "https://example.org/issues/MT-221"
     }
@@ -422,15 +418,15 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       identifier: issue.identifier,
       issue: issue,
       session_id: nil,
-      last_agent_message: nil,
-      last_agent_timestamp: nil,
-      last_agent_event: nil,
-      agent_input_tokens: 0,
-      agent_output_tokens: 0,
-      agent_total_tokens: 0,
-      agent_last_reported_input_tokens: 0,
-      agent_last_reported_output_tokens: 0,
-      agent_last_reported_total_tokens: 0,
+      last_claude_message: nil,
+      last_claude_timestamp: nil,
+      last_claude_event: nil,
+      claude_input_tokens: 0,
+      claude_output_tokens: 0,
+      claude_total_tokens: 0,
+      claude_last_reported_input_tokens: 0,
+      claude_last_reported_output_tokens: 0,
+      claude_last_reported_total_tokens: 0,
       started_at: started_at
     }
 
@@ -449,11 +445,11 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     send(
       pid,
-      {:agent_worker_update, issue_id,
+      {:claude_worker_update, issue_id,
        %{
          event: :notification,
          payload: %{
-           "method" => "agent/event/token_count",
+           "method" => "claude/event/token_count",
            "params" => %{
              "msg" => %{
                "type" => "event_msg",
@@ -503,15 +499,15 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       identifier: issue.identifier,
       issue: issue,
       session_id: nil,
-      last_agent_message: nil,
-      last_agent_timestamp: nil,
-      last_agent_event: nil,
-      agent_input_tokens: 0,
-      agent_output_tokens: 0,
-      agent_total_tokens: 0,
-      agent_last_reported_input_tokens: 0,
-      agent_last_reported_output_tokens: 0,
-      agent_last_reported_total_tokens: 0,
+      last_claude_message: nil,
+      last_claude_timestamp: nil,
+      last_claude_event: nil,
+      claude_input_tokens: 0,
+      claude_output_tokens: 0,
+      claude_total_tokens: 0,
+      claude_last_reported_input_tokens: 0,
+      claude_last_reported_output_tokens: 0,
+      claude_last_reported_total_tokens: 0,
       started_at: started_at
     }
 
@@ -523,11 +519,11 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     send(
       pid,
-      {:agent_worker_update, issue_id,
+      {:claude_worker_update, issue_id,
        %{
          event: :notification,
          payload: %{
-           "method" => "agent/event/token_count",
+           "method" => "claude/event/token_count",
            "params" => %{
              "msg" => %{
                "type" => "event_msg",
@@ -555,9 +551,9 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     snapshot = GenServer.call(pid, :snapshot)
     assert %{running: [snapshot_entry]} = snapshot
-    assert snapshot_entry.agent_input_tokens == 200
-    assert snapshot_entry.agent_output_tokens == 100
-    assert snapshot_entry.agent_total_tokens == 300
+    assert snapshot_entry.claude_input_tokens == 200
+    assert snapshot_entry.claude_output_tokens == 100
+    assert snapshot_entry.claude_total_tokens == 300
   end
 
   test "orchestrator token accounting accumulates monotonic thread token usage totals" do
@@ -591,15 +587,15 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       identifier: issue.identifier,
       issue: issue,
       session_id: nil,
-      last_agent_message: nil,
-      last_agent_timestamp: nil,
-      last_agent_event: nil,
-      agent_input_tokens: 0,
-      agent_output_tokens: 0,
-      agent_total_tokens: 0,
-      agent_last_reported_input_tokens: 0,
-      agent_last_reported_output_tokens: 0,
-      agent_last_reported_total_tokens: 0,
+      last_claude_message: nil,
+      last_claude_timestamp: nil,
+      last_claude_event: nil,
+      claude_input_tokens: 0,
+      claude_output_tokens: 0,
+      claude_total_tokens: 0,
+      claude_last_reported_input_tokens: 0,
+      claude_last_reported_output_tokens: 0,
+      claude_last_reported_total_tokens: 0,
       started_at: started_at
     }
 
@@ -615,7 +611,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
         ] do
       send(
         pid,
-        {:agent_worker_update, issue_id,
+        {:claude_worker_update, issue_id,
          %{
            event: :notification,
            payload: %{
@@ -629,9 +625,9 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     snapshot = GenServer.call(pid, :snapshot)
     assert %{running: [snapshot_entry]} = snapshot
-    assert snapshot_entry.agent_input_tokens == 10
-    assert snapshot_entry.agent_output_tokens == 4
-    assert snapshot_entry.agent_total_tokens == 14
+    assert snapshot_entry.claude_input_tokens == 10
+    assert snapshot_entry.claude_output_tokens == 4
+    assert snapshot_entry.claude_total_tokens == 14
   end
 
   test "orchestrator token accounting ignores last_token_usage without cumulative totals" do
@@ -665,15 +661,15 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       identifier: issue.identifier,
       issue: issue,
       session_id: nil,
-      last_agent_message: nil,
-      last_agent_timestamp: nil,
-      last_agent_event: nil,
-      agent_input_tokens: 0,
-      agent_output_tokens: 0,
-      agent_total_tokens: 0,
-      agent_last_reported_input_tokens: 0,
-      agent_last_reported_output_tokens: 0,
-      agent_last_reported_total_tokens: 0,
+      last_claude_message: nil,
+      last_claude_timestamp: nil,
+      last_claude_event: nil,
+      claude_input_tokens: 0,
+      claude_output_tokens: 0,
+      claude_total_tokens: 0,
+      claude_last_reported_input_tokens: 0,
+      claude_last_reported_output_tokens: 0,
+      claude_last_reported_total_tokens: 0,
       started_at: started_at
     }
 
@@ -685,11 +681,11 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     send(
       pid,
-      {:agent_worker_update, issue_id,
+      {:claude_worker_update, issue_id,
        %{
          event: :notification,
          payload: %{
-           "method" => "agent/event/token_count",
+           "method" => "claude/event/token_count",
            "params" => %{
              "msg" => %{
                "type" => "event_msg",
@@ -712,9 +708,9 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
 
     snapshot = GenServer.call(pid, :snapshot)
     assert %{running: [snapshot_entry]} = snapshot
-    assert snapshot_entry.agent_input_tokens == 0
-    assert snapshot_entry.agent_output_tokens == 0
-    assert snapshot_entry.agent_total_tokens == 0
+    assert snapshot_entry.claude_input_tokens == 0
+    assert snapshot_entry.claude_output_tokens == 0
+    assert snapshot_entry.claude_total_tokens == 0
   end
 
   test "orchestrator snapshot includes retry backoff entries" do
@@ -933,9 +929,9 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       identifier: "MT-STALL",
       issue: %Issue{id: issue_id, identifier: "MT-STALL", state: "In Progress"},
       session_id: "thread-stall-turn-stall",
-      last_agent_message: nil,
-      last_agent_timestamp: stale_activity_at,
-      last_agent_event: :notification,
+      last_claude_message: nil,
+      last_claude_timestamp: stale_activity_at,
+      last_claude_event: :notification,
       started_at: stale_activity_at
     }
 
@@ -981,7 +977,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
        %{
          running: [],
          retrying: [],
-         agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
          rate_limits: nil
        }}
 
@@ -1009,7 +1005,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
        %{
          running: [],
          retrying: [],
-         agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
          rate_limits: nil
        }}
 
@@ -1035,7 +1031,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
        %{
          running: [],
          retrying: [],
-         agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
          rate_limits: nil,
          polling: %{checking?: false, next_poll_in_ms: 2_000, poll_interval_ms: 30_000}
        }}
@@ -1049,7 +1045,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
        %{
          running: [],
          retrying: [],
-         agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
          rate_limits: nil,
          polling: %{checking?: true, next_poll_in_ms: nil, poll_interval_ms: 30_000}
        }}
@@ -1064,7 +1060,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
        %{
          running: [],
          retrying: [],
-         agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
          rate_limits: nil
        }}
 
@@ -1083,12 +1079,12 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
              identifier: "MT-777",
              state: "running",
              session_id: "thread-1234567890",
-             agent_app_server_pid: "4242",
-             agent_total_tokens: 3_200,
+             claude_app_server_pid: "4242",
+             claude_total_tokens: 3_200,
              runtime_seconds: 75,
              turn_count: 7,
-             last_agent_event: "turn_completed",
-             last_agent_message: %{
+             last_claude_event: "turn_completed",
+             last_claude_message: %{
                event: :notification,
                message: %{
                  "method" => "turn/completed",
@@ -1098,7 +1094,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
            }
          ],
          retrying: [],
-         agent_totals: %{
+         claude_totals: %{
            input_tokens: 90,
            output_tokens: 12,
            total_tokens: 102,
@@ -1119,7 +1115,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
        %{
          running: [],
          retrying: [],
-         agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
          rate_limits: nil
        }}
 
@@ -1276,17 +1272,17 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     assert disk_config.max_no_files > 0
   end
 
-  test "status dashboard renders last agent message in EVENT column" do
+  test "status dashboard renders last claude message in EVENT column" do
     row =
       StatusDashboard.format_running_summary_for_test(%{
         identifier: "MT-233",
         state: "running",
         session_id: "thread-1234567890",
-        agent_app_server_pid: "4242",
-        agent_total_tokens: 12,
+        claude_app_server_pid: "4242",
+        claude_total_tokens: 12,
         runtime_seconds: 15,
-        last_agent_event: :notification,
-        last_agent_message: %{
+        last_claude_event: :notification,
+        last_claude_message: %{
           event: :notification,
           message: %{
             "method" => "turn/completed",
@@ -1302,7 +1298,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     refute plain =~ " notification "
   end
 
-  test "status dashboard strips ANSI and control bytes from last agent message" do
+  test "status dashboard strips ANSI and control bytes from last claude message" do
     payload =
       "cmd: " <>
         <<27>> <>
@@ -1317,11 +1313,11 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
         identifier: "MT-898",
         state: "running",
         session_id: "thread-1234567890",
-        agent_app_server_pid: "4242",
-        agent_total_tokens: 12,
+        claude_app_server_pid: "4242",
+        claude_total_tokens: 12,
         runtime_seconds: 15,
-        last_agent_event: :notification,
-        last_agent_message: payload
+        last_claude_event: :notification,
+        last_claude_message: payload
       })
 
     plain = Regex.replace(~r/\e\[[0-9;]*m/, row, "")
@@ -1340,11 +1336,11 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
           identifier: "MT-598",
           state: "running",
           session_id: "thread-1234567890",
-          agent_app_server_pid: "4242",
-          agent_total_tokens: 123,
+          claude_app_server_pid: "4242",
+          claude_total_tokens: 123,
           runtime_seconds: 15,
-          last_agent_event: :notification,
-          last_agent_message: %{
+          last_claude_event: :notification,
+          last_claude_message: %{
             event: :notification,
             message: %{
               "method" => "turn/completed",
@@ -1361,7 +1357,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     assert plain =~ "turn completed (completed)"
   end
 
-  test "status dashboard humanizes full agent app-server event set" do
+  test "status dashboard humanizes full claude app-server event set" do
     event_cases = [
       {"turn/started", %{"params" => %{"turn" => %{"id" => "turn-1"}}}, "turn started"},
       {"turn/completed", %{"params" => %{"turn" => %{"status" => "completed"}}}, "turn completed"},
@@ -1401,7 +1397,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       message = Map.put(payload, "method", method)
 
       humanized =
-        StatusDashboard.humanize_agent_message(%{event: :notification, message: message})
+        StatusDashboard.humanize_claude_message(%{event: :notification, message: message})
 
       assert humanized =~ expected_fragment
     end)
@@ -1429,17 +1425,17 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       }
     }
 
-    assert StatusDashboard.humanize_agent_message(completed) =~
+    assert StatusDashboard.humanize_claude_message(completed) =~
              "dynamic tool call completed (linear_graphql)"
 
-    assert StatusDashboard.humanize_agent_message(failed) =~
+    assert StatusDashboard.humanize_claude_message(failed) =~
              "dynamic tool call failed (linear_graphql)"
 
-    assert StatusDashboard.humanize_agent_message(unsupported) =~
+    assert StatusDashboard.humanize_claude_message(unsupported) =~
              "unsupported dynamic tool call rejected (unknown_tool)"
   end
 
-  test "status dashboard unwraps nested agent payload envelopes" do
+  test "status dashboard unwraps nested claude payload envelopes" do
     wrapped = %{
       event: :notification,
       message: %{
@@ -1454,23 +1450,23 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       }
     }
 
-    assert StatusDashboard.humanize_agent_message(wrapped) =~ "turn completed"
-    assert StatusDashboard.humanize_agent_message(wrapped) =~ "in 10"
+    assert StatusDashboard.humanize_claude_message(wrapped) =~ "turn completed"
+    assert StatusDashboard.humanize_claude_message(wrapped) =~ "in 10"
   end
 
   test "status dashboard uses shell command line as exec command status text" do
     message = %{
       event: :notification,
       message: %{
-        "method" => "agent/event/exec_command_begin",
+        "method" => "claude/event/exec_command_begin",
         "params" => %{"msg" => %{"command" => "git status --short"}}
       }
     }
 
-    assert StatusDashboard.humanize_agent_message(message) == "git status --short"
+    assert StatusDashboard.humanize_claude_message(message) == "git status --short"
   end
 
-  test "status dashboard formats auto-approval updates from agent" do
+  test "status dashboard formats auto-approval updates from claude" do
     message = %{
       event: :approval_auto_approved,
       message: %{
@@ -1482,12 +1478,12 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       }
     }
 
-    humanized = StatusDashboard.humanize_agent_message(message)
+    humanized = StatusDashboard.humanize_claude_message(message)
     assert humanized =~ "command approval requested"
     assert humanized =~ "auto-approved"
   end
 
-  test "status dashboard formats auto-answered tool input updates from agent" do
+  test "status dashboard formats auto-answered tool input updates from claude" do
     message = %{
       event: :tool_input_auto_answered,
       message: %{
@@ -1499,7 +1495,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
       }
     }
 
-    humanized = StatusDashboard.humanize_agent_message(message)
+    humanized = StatusDashboard.humanize_claude_message(message)
     assert humanized =~ "tool requires user input"
     assert humanized =~ "auto-answered"
   end
@@ -1508,7 +1504,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     reasoning_message = %{
       event: :notification,
       message: %{
-        "method" => "agent/event/agent_reasoning",
+        "method" => "claude/event/agent_reasoning",
         "params" => %{
           "msg" => %{
             "payload" => %{"summaryText" => "compare retry paths for Linear polling"}
@@ -1520,7 +1516,7 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     message_delta = %{
       event: :notification,
       message: %{
-        "method" => "agent/event/agent_message_delta",
+        "method" => "claude/event/agent_message_delta",
         "params" => %{
           "msg" => %{
             "payload" => %{"delta" => "writing workpad reconciliation update"}
@@ -1532,18 +1528,18 @@ defmodule SymphonyElixir.OrchestratorStatusTest do
     fallback_reasoning = %{
       event: :notification,
       message: %{
-        "method" => "agent/event/agent_reasoning",
+        "method" => "claude/event/agent_reasoning",
         "params" => %{"msg" => %{"payload" => %{}}}
       }
     }
 
-    assert StatusDashboard.humanize_agent_message(reasoning_message) =~
+    assert StatusDashboard.humanize_claude_message(reasoning_message) =~
              "reasoning update: compare retry paths for Linear polling"
 
-    assert StatusDashboard.humanize_agent_message(message_delta) =~
+    assert StatusDashboard.humanize_claude_message(message_delta) =~
              "agent message streaming: writing workpad reconciliation update"
 
-    assert StatusDashboard.humanize_agent_message(fallback_reasoning) == "reasoning update"
+    assert StatusDashboard.humanize_claude_message(fallback_reasoning) == "reasoning update"
   end
 
   test "application stop renders offline status" do

--- a/elixir/test/symphony_elixir/ssh_test.exs
+++ b/elixir/test/symphony_elixir/ssh_test.exs
@@ -182,14 +182,14 @@ defmodule SymphonyElixir.SSHTest do
     System.put_env("PATH", fake_bin_dir <> ":" <> (System.get_env("PATH") || ""))
   end
 
-  defp wait_for_trace!(trace_file, attempts \\ 20)
+  defp wait_for_trace!(trace_file, attempts \\ 100)
   defp wait_for_trace!(trace_file, 0), do: flunk("timed out waiting for fake ssh trace at #{trace_file}")
 
   defp wait_for_trace!(trace_file, attempts) do
     if File.exists?(trace_file) and File.read!(trace_file) != "" do
       :ok
     else
-      Process.sleep(25)
+      Process.sleep(50)
       wait_for_trace!(trace_file, attempts - 1)
     end
   end

--- a/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
+++ b/elixir/test/symphony_elixir/status_dashboard_snapshot_test.exs
@@ -11,7 +11,7 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
        %{
          running: [],
          retrying: [],
-         agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
          rate_limits: nil
        }}
 
@@ -36,7 +36,7 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
        %{
          running: [],
          retrying: [],
-         agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
          rate_limits: nil
        }}
 
@@ -50,25 +50,25 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
          running: [
            running_entry(%{
              identifier: "MT-101",
-             codex_total_tokens: 120_450,
+             claude_total_tokens: 120_450,
              runtime_seconds: 785,
              turn_count: 11,
-             last_codex_event: "turn_completed",
-             last_codex_message: turn_completed_message("completed")
+             last_claude_event: "turn_completed",
+             last_claude_message: turn_completed_message("completed")
            }),
            running_entry(%{
              identifier: "MT-102",
              session_id: "thread-abcdef1234567890",
-             codex_app_server_pid: "5252",
-             codex_total_tokens: 89_200,
+             claude_app_server_pid: "5252",
+             claude_total_tokens: 89_200,
              runtime_seconds: 412,
              turn_count: 4,
-             last_codex_event: "codex/event/task_started",
-             last_codex_message: exec_command_message("mix test --cover")
+             last_claude_event: "claude/event/task_started",
+             last_claude_message: exec_command_message("mix test --cover")
            })
          ],
          retrying: [],
-         agent_totals: %{
+         claude_totals: %{
            input_tokens: 250_000,
            output_tokens: 18_500,
            total_tokens: 268_500,
@@ -93,11 +93,11 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
            running_entry(%{
              identifier: "MT-638",
              state: "retrying",
-             codex_total_tokens: 14_200,
+             claude_total_tokens: 14_200,
              runtime_seconds: 1_225,
              turn_count: 7,
-             last_codex_event: :notification,
-             last_codex_message: agent_message_delta("waiting on rate-limit backoff window")
+             last_claude_event: :notification,
+             last_claude_message: agent_message_delta("waiting on rate-limit backoff window")
            })
          ],
          retrying: [
@@ -126,7 +126,7 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
              error: "fourth queued retry should also render after removing the top-three limit"
            })
          ],
-         agent_totals: %{input_tokens: 18_000, output_tokens: 2_200, total_tokens: 20_200, seconds_running: 2_700},
+         claude_totals: %{input_tokens: 18_000, output_tokens: 2_200, total_tokens: 20_200, seconds_running: 2_700},
          rate_limits: %{
            limit_id: "gpt-5",
            primary: %{remaining: 0, limit: 20_000, reset_in_seconds: 95},
@@ -151,7 +151,7 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
              error: "error with \\nnewline"
            })
          ],
-         agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+         claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
          rate_limits: nil
        }}
 
@@ -174,15 +174,15 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
            running_entry(%{
              identifier: "MT-777",
              state: "running",
-             codex_total_tokens: 3_200,
+             claude_total_tokens: 3_200,
              runtime_seconds: 75,
              turn_count: 7,
-             last_codex_event: "codex/event/token_count",
-             last_codex_message: token_usage_message(90, 12, 102)
+             last_claude_event: "claude/event/token_count",
+             last_claude_message: token_usage_message(90, 12, 102)
            })
          ],
          retrying: [],
-         agent_totals: %{input_tokens: 90, output_tokens: 12, total_tokens: 102, seconds_running: 75},
+         claude_totals: %{input_tokens: 90, output_tokens: 12, total_tokens: 102, seconds_running: 75},
          rate_limits: %{
            limit_id: "priority-tier",
            primary: %{remaining: 100, limit: 100, reset_in_seconds: 1},
@@ -204,12 +204,12 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
         identifier: "MT-000",
         state: "running",
         session_id: "thread-1234567890",
-        codex_app_server_pid: "4242",
-        codex_total_tokens: 0,
+        claude_app_server_pid: "4242",
+        claude_total_tokens: 0,
         runtime_seconds: 0,
         turn_count: 1,
-        last_codex_event: :notification,
-        last_codex_message: turn_started_message()
+        last_claude_event: :notification,
+        last_claude_message: turn_started_message()
       },
       overrides
     )
@@ -252,7 +252,7 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
     %{
       event: :notification,
       message: %{
-        "method" => "codex/event/exec_command_begin",
+        "method" => "claude/event/exec_command_begin",
         "params" => %{"msg" => %{"command" => command}}
       }
     }
@@ -262,7 +262,7 @@ defmodule SymphonyElixir.StatusDashboardSnapshotTest do
     %{
       event: :notification,
       message: %{
-        "method" => "codex/event/agent_message_delta",
+        "method" => "claude/event/agent_message_delta",
         "params" => %{"msg" => %{"payload" => %{"delta" => delta}}}
       }
     }

--- a/elixir/test/symphony_elixir/workspace_and_config_test.exs
+++ b/elixir/test/symphony_elixir/workspace_and_config_test.exs
@@ -2,7 +2,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
   use SymphonyElixir.TestSupport
   alias Ecto.Changeset
   alias SymphonyElixir.Config.Schema
-  alias SymphonyElixir.Config.Schema.{Codex, StringOrMap}
+  alias SymphonyElixir.Config.Schema.StringOrMap
   alias SymphonyElixir.Linear.Client
 
   test "workspace bootstrap can be implemented in after_create hook" do
@@ -501,7 +501,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       max_concurrent_agents: 3,
       running: %{},
       claimed: MapSet.new(),
-      agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+      claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
       retry_attempts: %{}
     }
 
@@ -523,7 +523,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       max_concurrent_agents: 3,
       running: %{},
       claimed: MapSet.new(),
-      agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+      claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
       retry_attempts: %{}
     }
 
@@ -543,7 +543,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
       max_concurrent_agents: 3,
       running: %{},
       claimed: MapSet.new(),
-      agent_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
+      claude_totals: %{input_tokens: 0, output_tokens: 0, total_tokens: 0, seconds_running: 0},
       retry_attempts: %{}
     }
 
@@ -719,7 +719,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     end
   end
 
-  test "config reads defaults for optional settings" do
+  test "config reads defaults and overrides for claude runtime settings" do
     previous_linear_api_key = System.get_env("LINEAR_API_KEY")
     on_exit(fn -> restore_env("LINEAR_API_KEY", previous_linear_api_key) end)
     System.delete_env("LINEAR_API_KEY")
@@ -727,12 +727,11 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     write_workflow_file!(Workflow.workflow_file_path(),
       workspace_root: nil,
       max_concurrent_agents: nil,
-      codex_approval_policy: nil,
-      codex_thread_sandbox: nil,
-      codex_turn_sandbox_policy: nil,
-      codex_turn_timeout_ms: nil,
-      codex_read_timeout_ms: nil,
-      codex_stall_timeout_ms: nil,
+      claude_command: nil,
+      claude_permission_mode: nil,
+      claude_turn_timeout_ms: nil,
+      claude_read_timeout_ms: nil,
+      claude_stall_timeout_ms: nil,
       tracker_api_token: nil,
       tracker_project_slug: nil
     )
@@ -744,71 +743,34 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert config.workspace.root == Path.join(System.tmp_dir!(), "symphony_workspaces")
     assert config.worker.max_concurrent_agents_per_host == nil
     assert config.agent.max_concurrent_agents == 10
-    assert config.codex.command == "codex app-server"
+    assert config.claude.command == "claude-app-server --listen stdio://"
+    assert config.claude.permission_mode == "dontAsk"
+    assert config.claude.turn_timeout_ms == 3_600_000
+    assert config.claude.read_timeout_ms == 5_000
+    assert config.claude.stall_timeout_ms == 300_000
+    assert Config.claude_command() == "claude-app-server --listen stdio://"
+    assert Config.agent_command() == "claude-app-server --listen stdio://"
 
-    assert config.codex.approval_policy == %{
-             "reject" => %{
-               "sandbox_approval" => true,
-               "rules" => true,
-               "mcp_elicitations" => true
-             }
-           }
-
-    assert config.codex.thread_sandbox == "workspace-write"
-
-    assert {:ok, canonical_default_workspace_root} =
-             SymphonyElixir.PathSafety.canonicalize(Path.join(System.tmp_dir!(), "symphony_workspaces"))
-
-    assert Config.codex_turn_sandbox_policy() == %{
-             "type" => "workspaceWrite",
-             "writableRoots" => [canonical_default_workspace_root],
-             "readOnlyAccess" => %{"type" => "fullAccess"},
-             "networkAccess" => false,
-             "excludeTmpdirEnvVar" => false,
-             "excludeSlashTmp" => false
-           }
-
-    assert config.codex.turn_timeout_ms == 3_600_000
-    assert config.codex.read_timeout_ms == 5_000
-    assert config.codex.stall_timeout_ms == 300_000
+    assert {:ok, runtime_settings} = Config.claude_runtime_settings()
+    assert runtime_settings.command == "claude-app-server --listen stdio://"
+    assert runtime_settings.permission_mode == "dontAsk"
+    assert runtime_settings.turn_timeout_ms == 3_600_000
+    assert runtime_settings.read_timeout_ms == 5_000
+    assert runtime_settings.stall_timeout_ms == 300_000
 
     write_workflow_file!(Workflow.workflow_file_path(),
-      codex_command: "codex --config 'model=\"gpt-5.5\"' app-server"
+      claude_command: "claude --config 'model=\"gpt-5.5\"' app-server",
+      claude_permission_mode: "bypassPermissions"
     )
 
-    assert Config.settings!().codex.command ==
-             "codex --config 'model=\"gpt-5.5\"' app-server"
+    assert Config.settings!().claude.command ==
+             "claude --config 'model=\"gpt-5.5\"' app-server"
 
-    explicit_root =
-      Path.join(
-        System.tmp_dir!(),
-        "symphony-elixir-explicit-sandbox-root-#{System.unique_integer([:positive])}"
-      )
+    assert Config.settings!().claude.permission_mode == "bypassPermissions"
+    assert Config.agent_command() == "claude --config 'model=\"gpt-5.5\"' app-server"
 
-    explicit_workspace = Path.join(explicit_root, "MT-EXPLICIT")
-    explicit_cache = Path.join(explicit_workspace, "cache")
-    File.mkdir_p!(explicit_cache)
-
-    on_exit(fn -> File.rm_rf(explicit_root) end)
-
-    write_workflow_file!(Workflow.workflow_file_path(),
-      workspace_root: explicit_root,
-      codex_approval_policy: "on-request",
-      codex_thread_sandbox: "workspace-write",
-      codex_turn_sandbox_policy: %{
-        type: "workspaceWrite",
-        writableRoots: [explicit_workspace, explicit_cache]
-      }
-    )
-
-    config = Config.settings!()
-    assert config.codex.approval_policy == "on-request"
-    assert config.codex.thread_sandbox == "workspace-write"
-
-    assert Config.codex_turn_sandbox_policy(explicit_workspace) == %{
-             "type" => "workspaceWrite",
-             "writableRoots" => [explicit_workspace, explicit_cache]
-           }
+    assert {:ok, runtime_settings} = Config.agent_runtime_settings()
+    assert runtime_settings.permission_mode == "bypassPermissions"
 
     write_workflow_file!(Workflow.workflow_file_path(), tracker_active_states: ",")
     assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
@@ -822,17 +784,17 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
     assert message =~ "worker.max_concurrent_agents_per_host"
 
-    write_workflow_file!(Workflow.workflow_file_path(), codex_turn_timeout_ms: "bad")
+    write_workflow_file!(Workflow.workflow_file_path(), claude_turn_timeout_ms: "bad")
     assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
-    assert message =~ "codex.turn_timeout_ms"
+    assert message =~ "claude.turn_timeout_ms"
 
-    write_workflow_file!(Workflow.workflow_file_path(), codex_read_timeout_ms: "bad")
+    write_workflow_file!(Workflow.workflow_file_path(), claude_read_timeout_ms: "bad")
     assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
-    assert message =~ "codex.read_timeout_ms"
+    assert message =~ "claude.read_timeout_ms"
 
-    write_workflow_file!(Workflow.workflow_file_path(), codex_stall_timeout_ms: "bad")
+    write_workflow_file!(Workflow.workflow_file_path(), claude_stall_timeout_ms: "bad")
     assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
-    assert message =~ "codex.stall_timeout_ms"
+    assert message =~ "claude.stall_timeout_ms"
 
     write_workflow_file!(Workflow.workflow_file_path(),
       tracker_active_states: %{todo: true},
@@ -851,40 +813,12 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
     assert {:error, {:invalid_workflow_config, _message}} = Config.validate!()
 
-    write_workflow_file!(Workflow.workflow_file_path(), codex_approval_policy: "")
-    assert :ok = Config.validate!()
-    assert Config.settings!().codex.approval_policy == ""
-
-    write_workflow_file!(Workflow.workflow_file_path(), codex_thread_sandbox: "")
-    assert :ok = Config.validate!()
-    assert Config.settings!().codex.thread_sandbox == ""
-
-    write_workflow_file!(Workflow.workflow_file_path(), codex_turn_sandbox_policy: "bad")
+    write_workflow_file!(Workflow.workflow_file_path(), claude_permission_mode: "")
     assert {:error, {:invalid_workflow_config, message}} = Config.validate!()
-    assert message =~ "codex.turn_sandbox_policy"
+    assert message =~ "claude.permission_mode"
 
-    write_workflow_file!(Workflow.workflow_file_path(),
-      codex_approval_policy: "future-policy",
-      codex_thread_sandbox: "future-sandbox",
-      codex_turn_sandbox_policy: %{
-        type: "futureSandbox",
-        nested: %{flag: true}
-      }
-    )
-
-    config = Config.settings!()
-    assert config.codex.approval_policy == "future-policy"
-    assert config.codex.thread_sandbox == "future-sandbox"
-
-    assert :ok = Config.validate!()
-
-    assert Config.codex_turn_sandbox_policy() == %{
-             "type" => "futureSandbox",
-             "nested" => %{"flag" => true}
-           }
-
-    write_workflow_file!(Workflow.workflow_file_path(), codex_command: "codex app-server")
-    assert Config.settings!().codex.command == "codex app-server"
+    write_workflow_file!(Workflow.workflow_file_path(), claude_command: "claude app-server")
+    assert Config.settings!().claude.command == "claude app-server"
   end
 
   test "config resolves $VAR references for env-backed secret and path values" do
@@ -892,7 +826,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     api_key_env_var = "SYMP_LINEAR_API_KEY_#{System.unique_integer([:positive])}"
     workspace_root = Path.join("/tmp", "symphony-workspace-root")
     api_key = "resolved-secret"
-    codex_bin = Path.join(["~", "bin", "codex"])
+    claude_bin = Path.join(["~", "bin", "claude"])
 
     previous_workspace_root = System.get_env(workspace_env_var)
     previous_api_key = System.get_env(api_key_env_var)
@@ -908,13 +842,13 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     write_workflow_file!(Workflow.workflow_file_path(),
       tracker_api_token: "$#{api_key_env_var}",
       workspace_root: "$#{workspace_env_var}",
-      codex_command: "#{codex_bin} app-server"
+      claude_command: "#{claude_bin} app-server"
     )
 
     config = Config.settings!()
     assert config.tracker.api_key == api_key
     assert config.workspace.root == Path.expand(workspace_root)
-    assert config.codex.command == "#{codex_bin} app-server"
+    assert config.claude.command == "#{claude_bin} app-server"
   end
 
   test "config no longer resolves legacy env: references" do
@@ -1004,7 +938,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
            ]
   end
 
-  test "schema parse normalizes policy keys and env-backed fallbacks" do
+  test "schema parse normalizes claude keys and env-backed fallbacks" do
     missing_workspace_env = "SYMP_MISSING_WORKSPACE_#{System.unique_integer([:positive])}"
     empty_secret_env = "SYMP_EMPTY_SECRET_#{System.unique_integer([:positive])}"
     missing_secret_env = "SYMP_MISSING_SECRET_#{System.unique_integer([:positive])}"
@@ -1030,15 +964,13 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
              Schema.parse(%{
                tracker: %{api_key: "$#{empty_secret_env}"},
                workspace: %{root: "$#{missing_workspace_env}"},
-               codex: %{approval_policy: %{reject: %{sandbox_approval: true}}}
+               claude: %{permission_mode: "bypassPermissions"}
              })
 
     assert settings.tracker.api_key == nil
     assert settings.workspace.root == Path.join(System.tmp_dir!(), "symphony_workspaces")
 
-    assert settings.codex.approval_policy == %{
-             "reject" => %{"sandbox_approval" => true}
-           }
+    assert settings.claude.permission_mode == "bypassPermissions"
 
     assert {:ok, settings} =
              Schema.parse(%{
@@ -1050,78 +982,40 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
     assert settings.workspace.root == Path.join(System.tmp_dir!(), "symphony_workspaces")
   end
 
-  test "schema resolves sandbox policies from explicit and default workspaces" do
-    explicit_policy = %{"type" => "workspaceWrite", "writableRoots" => ["/tmp/explicit"]}
+  test "schema applies claude defaults for command and permission mode" do
+    assert {:ok, settings} =
+             Schema.parse(%{
+               workspace: %{root: "/tmp/ignored"},
+               claude: %{}
+             })
 
-    assert Schema.resolve_turn_sandbox_policy(%Schema{
-             codex: %Codex{turn_sandbox_policy: explicit_policy},
-             workspace: %Schema.Workspace{root: "/tmp/ignored"}
-           }) == explicit_policy
-
-    assert Schema.resolve_turn_sandbox_policy(%Schema{
-             codex: %Codex{turn_sandbox_policy: nil},
-             workspace: %Schema.Workspace{root: ""}
-           }) == %{
-             "type" => "workspaceWrite",
-             "writableRoots" => [Path.expand(Path.join(System.tmp_dir!(), "symphony_workspaces"))],
-             "readOnlyAccess" => %{"type" => "fullAccess"},
-             "networkAccess" => false,
-             "excludeTmpdirEnvVar" => false,
-             "excludeSlashTmp" => false
-           }
-
-    assert Schema.resolve_turn_sandbox_policy(
-             %Schema{
-               codex: %Codex{turn_sandbox_policy: nil},
-               workspace: %Schema.Workspace{root: "/tmp/ignored"}
-             },
-             "/tmp/workspace"
-           ) == %{
-             "type" => "workspaceWrite",
-             "writableRoots" => [Path.expand("/tmp/workspace")],
-             "readOnlyAccess" => %{"type" => "fullAccess"},
-             "networkAccess" => false,
-             "excludeTmpdirEnvVar" => false,
-             "excludeSlashTmp" => false
-           }
+    assert settings.workspace.root == "/tmp/ignored"
+    assert settings.claude.command == "claude-app-server --listen stdio://"
+    assert settings.claude.permission_mode == "dontAsk"
+    assert settings.claude.turn_timeout_ms == 3_600_000
+    assert settings.claude.read_timeout_ms == 5_000
+    assert settings.claude.stall_timeout_ms == 300_000
   end
 
-  test "schema keeps workspace roots raw while sandbox helpers expand only for local use" do
+  test "schema keeps workspace roots raw while claude runtime settings use defaults" do
     assert {:ok, settings} =
              Schema.parse(%{
                workspace: %{root: "~/.symphony-workspaces"},
-               codex: %{}
+               claude: %{}
              })
 
     assert settings.workspace.root == "~/.symphony-workspaces"
 
-    assert Schema.resolve_turn_sandbox_policy(settings) == %{
-             "type" => "workspaceWrite",
-             "writableRoots" => [Path.expand("~/.symphony-workspaces")],
-             "readOnlyAccess" => %{"type" => "fullAccess"},
-             "networkAccess" => false,
-             "excludeTmpdirEnvVar" => false,
-             "excludeSlashTmp" => false
-           }
-
-    assert {:ok, remote_policy} =
-             Schema.resolve_runtime_turn_sandbox_policy(settings, nil, remote: true)
-
-    assert remote_policy == %{
-             "type" => "workspaceWrite",
-             "writableRoots" => ["~/.symphony-workspaces"],
-             "readOnlyAccess" => %{"type" => "fullAccess"},
-             "networkAccess" => false,
-             "excludeTmpdirEnvVar" => false,
-             "excludeSlashTmp" => false
-           }
+    assert {:ok, runtime_settings} = Config.claude_runtime_settings(settings.workspace.root)
+    assert runtime_settings.command == "claude-app-server --listen stdio://"
+    assert runtime_settings.permission_mode == "dontAsk"
   end
 
-  test "runtime sandbox policy resolution passes explicit policies through unchanged" do
+  test "claude runtime settings preserve explicit command and permission mode" do
     test_root =
       Path.join(
         System.tmp_dir!(),
-        "symphony-elixir-runtime-sandbox-#{System.unique_integer([:positive])}"
+        "symphony-elixir-runtime-settings-#{System.unique_integer([:positive])}"
       )
 
     try do
@@ -1131,35 +1025,28 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_turn_sandbox_policy: %{
-          type: "workspaceWrite",
-          writableRoots: ["relative/path"],
-          networkAccess: true
-        }
+        claude_command: "/opt/bin/claude-app-server --listen stdio://",
+        claude_permission_mode: "bypassPermissions",
+        claude_turn_timeout_ms: 1234,
+        claude_read_timeout_ms: 234,
+        claude_stall_timeout_ms: 0
       )
 
-      assert {:ok, runtime_settings} = Config.codex_runtime_settings(issue_workspace)
+      assert {:ok, runtime_settings} = Config.claude_runtime_settings(issue_workspace)
 
-      assert runtime_settings.turn_sandbox_policy == %{
-               "type" => "workspaceWrite",
-               "writableRoots" => ["relative/path"],
-               "networkAccess" => true
-             }
+      assert runtime_settings.command == "/opt/bin/claude-app-server --listen stdio://"
+      assert runtime_settings.permission_mode == "bypassPermissions"
+      assert runtime_settings.turn_timeout_ms == 1234
+      assert runtime_settings.read_timeout_ms == 234
+      assert runtime_settings.stall_timeout_ms == 0
 
       write_workflow_file!(Workflow.workflow_file_path(),
         workspace_root: workspace_root,
-        codex_turn_sandbox_policy: %{
-          type: "futureSandbox",
-          nested: %{flag: true}
-        }
+        claude_command: "custom-claude app-server"
       )
 
-      assert {:ok, runtime_settings} = Config.codex_runtime_settings(issue_workspace)
-
-      assert runtime_settings.turn_sandbox_policy == %{
-               "type" => "futureSandbox",
-               "nested" => %{"flag" => true}
-             }
+      assert {:ok, runtime_settings} = Config.claude_runtime_settings(issue_workspace)
+      assert runtime_settings.command == "custom-claude app-server"
     after
       File.rm_rf(test_root)
     end
@@ -1174,7 +1061,7 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
              SymphonyElixir.PathSafety.canonicalize(path)
   end
 
-  test "runtime sandbox policy resolution defaults when omitted and ignores workspace for explicit policies" do
+  test "claude runtime settings ignore workspace and preserve explicit values" do
     test_root =
       Path.join(
         System.tmp_dir!(),
@@ -1191,43 +1078,32 @@ defmodule SymphonyElixir.WorkspaceAndConfigTest do
 
       settings = Config.settings!()
 
-      assert {:ok, canonical_workspace_root} =
-               SymphonyElixir.PathSafety.canonicalize(workspace_root)
+      assert {:ok, runtime_settings} = Config.claude_runtime_settings(settings.workspace.root)
+      assert runtime_settings.command == "claude-app-server --listen stdio://"
+      assert runtime_settings.permission_mode == "dontAsk"
 
-      assert {:ok, default_policy} = Schema.resolve_runtime_turn_sandbox_policy(settings)
-      assert default_policy["type"] == "workspaceWrite"
-      assert default_policy["writableRoots"] == [canonical_workspace_root]
+      write_workflow_file!(Workflow.workflow_file_path(),
+        workspace_root: workspace_root,
+        claude_command: "/opt/bin/claude-app-server --listen stdio://",
+        claude_permission_mode: "bypassPermissions",
+        claude_turn_timeout_ms: 123,
+        claude_read_timeout_ms: 456,
+        claude_stall_timeout_ms: 0
+      )
 
-      assert {:ok, blank_workspace_policy} =
-               Schema.resolve_runtime_turn_sandbox_policy(settings, "")
-
-      assert blank_workspace_policy == default_policy
-
-      read_only_settings = %{
-        settings
-        | codex: %{settings.codex | turn_sandbox_policy: %{"type" => "readOnly", "networkAccess" => true}}
-      }
-
-      assert {:ok, %{"type" => "readOnly", "networkAccess" => true}} =
-               Schema.resolve_runtime_turn_sandbox_policy(read_only_settings, 123)
-
-      future_settings = %{
-        settings
-        | codex: %{settings.codex | turn_sandbox_policy: %{"type" => "futureSandbox", "nested" => %{"flag" => true}}}
-      }
-
-      assert {:ok, %{"type" => "futureSandbox", "nested" => %{"flag" => true}}} =
-               Schema.resolve_runtime_turn_sandbox_policy(future_settings, 123)
-
-      assert {:error, {:unsafe_turn_sandbox_policy, {:invalid_workspace_root, 123}}} =
-               Schema.resolve_runtime_turn_sandbox_policy(settings, 123)
+      assert {:ok, runtime_settings} = Config.claude_runtime_settings(issue_workspace)
+      assert runtime_settings.command == "/opt/bin/claude-app-server --listen stdio://"
+      assert runtime_settings.permission_mode == "bypassPermissions"
+      assert runtime_settings.turn_timeout_ms == 123
+      assert runtime_settings.read_timeout_ms == 456
+      assert runtime_settings.stall_timeout_ms == 0
     after
       File.rm_rf(test_root)
     end
   end
 
   test "workflow prompt is used when building base prompt" do
-    workflow_prompt = "Workflow prompt body used as codex instruction."
+    workflow_prompt = "Workflow prompt body used as claude instruction."
 
     write_workflow_file!(Workflow.workflow_file_path(), prompt: workflow_prompt)
     assert Config.workflow_prompt() == workflow_prompt


### PR DESCRIPTION
## Summary
- replace Codex runtime/config naming with Claude app-server runtime support
- add Claude app-server client modules and update workflow/docs/tests for Claude-only operation
- add repo-local `.claude` skills and live E2E Docker dependencies for `logitropic/claude-app-server` plus Claude Code

## Validation
- `mise exec -- mix test` passed: 230 tests, 0 failures, 2 skipped
