### PR TITLE
refactor: convert openai/symphony references to logitropic/symphony

### DIFF
--- a/.codex/skills/commit/SKILL.md
+++ b/.codex/skills/commit/SKILL.md
@@ -40,7 +40,7 @@ description:
    - Summary of key changes (what changed).
    - Rationale and trade-offs (why it changed).
    - Tests or validation run (or explicit note if not run).
-9. Append a `Co-authored-by` trailer for Codex using `Codex <codex@openai.com>`
+9. Append a `Co-authored-by` trailer for Codex using `Codex <codex@logitropic.com>`
    unless the user explicitly requests a different identity.
 10. Wrap body lines at 72 characters.
 11. Create the commit message with a here-doc or temp file and use
@@ -71,5 +71,5 @@ Rationale:
 Tests:
 - <command or "not run (reason)">
 
-Co-authored-by: Codex <codex@openai.com>
+Co-authored-by: Codex <codex@logitropic.com>
 ```

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2025 OpenAI
+Copyright 2025 Logitropic
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _In this [demo video](.github/media/symphony-demo.mp4), Symphony monitors a Line
 ### Requirements
 
 Symphony works best in codebases that have adopted
-[harness engineering](https://openai.com/index/harness-engineering/). Symphony is the next step --
+[harness engineering](https://logitropic.com/index/harness-engineering/). Symphony is the next step --
 moving from managing coding agents to managing work that needs to get done.
 
 ### Option 1. Make your own
@@ -23,7 +23,7 @@ moving from managing coding agents to managing work that needs to get done.
 Tell your favorite coding agent to build Symphony in a programming language of your choice:
 
 > Implement Symphony according to the following spec:
-> https://github.com/openai/symphony/blob/main/SPEC.md
+> https://github.com/logitropic/symphony/blob/main/SPEC.md
 
 ### Option 2. Use our experimental reference implementation
 
@@ -32,7 +32,7 @@ and run the Elixir-based Symphony implementation. You can also ask your favorite
 help with the setup:
 
 > Set up Symphony for my repository based on
-> https://github.com/openai/symphony/blob/main/elixir/README.md
+> https://github.com/logitropic/symphony/blob/main/elixir/README.md
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -940,7 +940,7 @@ RECOMMENDED additional process settings:
 
 ### 10.2 Session Startup Responsibilities
 
-Reference: https://developers.openai.com/codex/app-server/
+Reference: https://developers.logitropic.com/codex/app-server/
 
 Startup MUST follow the targeted Codex app-server contract. Symphony additionally requires the
 client to:

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -15,7 +15,7 @@ This directory contains the current Elixir/OTP implementation of Symphony, based
 
 1. Polls Linear for candidate work
 2. Creates a workspace per issue
-3. Launches Codex in [App Server mode](https://developers.openai.com/codex/app-server/) inside the
+3. Launches Codex in [App Server mode](https://developers.logitropic.com/codex/app-server/) inside the
    workspace
 4. Sends a workflow prompt to Codex
 5. Keeps Codex working on the issue until the work is done
@@ -29,7 +29,7 @@ Symphony stops the active agent for that issue and cleans up matching workspaces
 ## How to use it
 
 1. Make sure your codebase is set up to work well with agents: see
-   [Harness engineering](https://openai.com/index/harness-engineering/).
+   [Harness engineering](https://logitropic.com/index/harness-engineering/).
 2. Get a new personal token in Linear via Settings → Security & access → Personal API keys, and
    set it as the `LINEAR_API_KEY` environment variable.
 3. Copy this directory's `WORKFLOW.md` to your repo.
@@ -56,7 +56,7 @@ mise exec -- elixir --version
 ## Run
 
 ```bash
-git clone https://github.com/openai/symphony
+git clone https://github.com/logitropic/symphony
 cd symphony/elixir
 mise trust
 mise install

--- a/elixir/WORKFLOW.md
+++ b/elixir/WORKFLOW.md
@@ -19,7 +19,7 @@ workspace:
   root: ~/code/symphony-workspaces
 hooks:
   after_create: |
-    git clone --depth 1 https://github.com/openai/symphony .
+    git clone --depth 1 https://github.com/logitropic/symphony .
     if command -v mise >/dev/null 2>&1; then
       cd elixir && mise trust && mise exec -- mix deps.get
     fi

--- a/elixir/lib/mix/tasks/workspace.before_remove.ex
+++ b/elixir/lib/mix/tasks/workspace.before_remove.ex
@@ -12,10 +12,10 @@ defmodule Mix.Tasks.Workspace.BeforeRemove do
 
       mix workspace.before_remove
       mix workspace.before_remove --branch feature/my-branch
-      mix workspace.before_remove --repo openai/symphony
+      mix workspace.before_remove --repo logitropic/symphony
   """
 
-  @default_repo "openai/symphony"
+  @default_repo "logitropic/symphony"
 
   @impl Mix.Task
   def run(args) do

--- a/elixir/test/mix/tasks/workspace_before_remove_test.exs
+++ b/elixir/test/mix/tasks/workspace_before_remove_test.exs
@@ -92,10 +92,10 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
         log = File.read!(log_path)
 
         assert log =~
-                 "pr list --repo openai/symphony --head feature/workpad --state open --json number --jq .[].number"
+                 "pr list --repo logitropic/symphony --head feature/workpad --state open --json number --jq .[].number"
 
-        assert log =~ "pr close 101 --repo openai/symphony"
-        assert log =~ "pr close 102 --repo openai/symphony"
+        assert log =~ "pr close 101 --repo logitropic/symphony"
+        assert log =~ "pr close 102 --repo logitropic/symphony"
       end
     )
   end
@@ -115,9 +115,9 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
       log = File.read!(log_path)
 
       assert log =~ "auth status"
-      assert log =~ "pr list --repo openai/symphony --head feature/workpad --state open --json number --jq .[].number"
-      assert log =~ "pr close 101 --repo openai/symphony"
-      assert log =~ "pr close 102 --repo openai/symphony"
+      assert log =~ "pr list --repo logitropic/symphony --head feature/workpad --state open --json number --jq .[].number"
+      assert log =~ "pr close 101 --repo logitropic/symphony"
+      assert log =~ "pr close 102 --repo logitropic/symphony"
 
       {second_output, error_output} =
         capture_task_output(fn ->
@@ -161,8 +161,8 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
         assert error_output =~ "Failed to close PR #102 for branch feature/no-output: exit 17"
         refute error_output =~ "output="
         log = File.read!(log_path)
-        assert log =~ "pr list --repo openai/symphony --head feature/no-output --state open --json number --jq .[].number"
-        assert log =~ "pr close 102 --repo openai/symphony"
+        assert log =~ "pr list --repo logitropic/symphony --head feature/no-output --state open --json number --jq .[].number"
+        assert log =~ "pr close 102 --repo logitropic/symphony"
       end
     )
   end
@@ -195,7 +195,7 @@ defmodule Mix.Tasks.Workspace.BeforeRemoveTest do
         assert log =~ "auth status"
 
         assert log =~
-                 "pr list --repo openai/symphony --head feature/list-fails --state open --json number --jq .[].number"
+                 "pr list --repo logitropic/symphony --head feature/list-fails --state open --json number --jq .[].number"
 
         refute log =~ "pr close"
       end

--- a/elixir/test/support/live_e2e_docker/Dockerfile
+++ b/elixir/test/support/live_e2e_docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN install -d -m 700 /root/.ssh /root/.codex /run/symphony/ssh /var/run/sshd
 
-RUN npm install --global @openai/codex
+RUN npm install --global @logitropic/codex
 
 COPY symphony-live-worker.conf /etc/ssh/sshd_config.d/symphony-live-worker.conf
 COPY live_worker_entrypoint.sh /usr/local/bin/symphony-live-worker

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -105,7 +105,7 @@ defmodule SymphonyElixir.CoreTest do
 
     hooks = Map.get(config, "hooks", %{})
     assert is_map(hooks)
-    assert Map.get(hooks, "after_create") =~ "git clone --depth 1 https://github.com/openai/symphony ."
+    assert Map.get(hooks, "after_create") =~ "git clone --depth 1 https://github.com/logitropic/symphony ."
     assert Map.get(hooks, "after_create") =~ "cd elixir && mise trust"
     assert Map.get(hooks, "after_create") =~ "mise exec -- mix deps.get"
     assert Map.get(hooks, "before_remove") =~ "cd elixir && mise exec -- mix workspace.before_remove"


### PR DESCRIPTION
Convert all remaining OpenAI references to Logitropic references across the codebase.

Closes SYM-11